### PR TITLE
Use well ROI in measurement, if `whole_well=True` (closes #103)

### DIFF
--- a/fractal_tasks_core/image_labeling.py
+++ b/fractal_tasks_core/image_labeling.py
@@ -39,7 +39,6 @@ __OME_NGFF_VERSION__ = fractal_tasks_core.__OME_NGFF_VERSION__
 
 def segment_FOV(
     column,
-    block_info=None,
     model=None,
     do_3D=True,
     anisotropy=None,

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -140,12 +140,12 @@ def prepare_well_ROI_table(
     return adata
 
 
-def convert_FOV_ROIs_3D_to_2D(
+def convert_ROIs_from_3D_to_2D(
     adata: ad.AnnData = None, pixel_size_z: float = None
 ) -> ad.AnnData:
 
     if pixel_size_z is None:
-        raise Exception("Missing pixel_size_z in convert_FOV_ROIs_3D_to_2D")
+        raise Exception("Missing pixel_size_z in convert_ROIs_from_3D_to_2D")
 
     # Compress a 3D stack of images to a single Z plane,
     # with thickness equal to pixel_size_z
@@ -161,7 +161,7 @@ def convert_FOV_ROIs_3D_to_2D(
     new_adata = ad.AnnData(X=df)
 
     # Rename rows and columns
-    adata.obs_names = "FOV_" + new_adata.obs.index
+    new_adata.obs_names = adata.obs_names
     new_adata.var_names = list(map(str, df.columns))
 
     return new_adata

--- a/fractal_tasks_core/measurement.py
+++ b/fractal_tasks_core/measurement.py
@@ -27,8 +27,8 @@ def measurement(
     labeling_channel: str = None,
     level: int = 0,
     workflow_file: str = None,
-    table_name: str = None,
-    whole_well: str = False,
+    ROI_table_name: str = "FOV_ROI_table",
+    measurement_table_name: str = "measurement",
 ):
 
     # Pre-processing of task inputs
@@ -109,10 +109,6 @@ def measurement(
     )
 
     # Create list of indices
-    if whole_well:
-        ROI_table_name = "well_ROI_table"
-    else:
-        ROI_table_name = "FOV_ROI_table"
     ROI_table = ad.read_zarr(f"{in_path}/{component}/tables/{ROI_table_name}")
     list_indices = convert_ROI_table_to_indices(
         ROI_table,
@@ -122,7 +118,9 @@ def measurement(
     )
 
     # Check that the target group is not already there, or fail fast
-    target_table_folder = f"{in_path}/{component}/tables/{table_name}"
+    target_table_folder = (
+        f"{in_path}/{component}/tables/{measurement_table_name}"
+    )
     if os.path.isdir(target_table_folder):
         raise Exception(f"ERROR: {target_table_folder} already exists.")
 
@@ -178,7 +176,7 @@ def measurement(
 
     # Write to zarr group
     group_tables = zarr.group(f"{in_path}/{component}/tables/")
-    write_elem(group_tables, table_name, measurement_table)
+    write_elem(group_tables, measurement_table_name, measurement_table)
 
 
 if __name__ == "__main__":

--- a/fractal_tasks_core/measurement.py
+++ b/fractal_tasks_core/measurement.py
@@ -103,26 +103,23 @@ def measurement(
         img = img[0, :, :]
         label_img_up = label_img_up[0, :, :]
 
+    # Read pixel sizes from zattrs file
+    full_res_pxl_sizes_zyx = extract_zyx_pixel_sizes(
+        f"{in_path}/{component}/.zattrs", level=0
+    )
+
     # Create list of indices
     if whole_well:
-        list_indices = [[0, img_shape[0], 0, img_shape[1], 0, img_shape[2]]]
+        ROI_table_name = "well_ROI_table"
     else:
-        # Read FOV ROIs
-        FOV_ROI_table = ad.read_zarr(
-            f"{in_path}/{component}/tables/FOV_ROI_table"
-        )
-
-        # Read pixel sizes from zattrs file
-        full_res_pxl_sizes_zyx = extract_zyx_pixel_sizes(
-            f"{in_path}/{component}/.zattrs", level=0
-        )
-
-        list_indices = convert_ROI_table_to_indices(
-            FOV_ROI_table,
-            level=level,
-            coarsening_xy=coarsening_xy,
-            full_res_pxl_sizes_zyx=full_res_pxl_sizes_zyx,
-        )
+        ROI_table_name = "FOV_ROI_table"
+    ROI_table = ad.read_zarr(f"{in_path}/{component}/tables/{ROI_table_name}")
+    list_indices = convert_ROI_table_to_indices(
+        ROI_table,
+        level=level,
+        coarsening_xy=coarsening_xy,
+        full_res_pxl_sizes_zyx=full_res_pxl_sizes_zyx,
+    )
 
     # Check that the target group is not already there, or fail fast
     target_table_folder = f"{in_path}/{component}/tables/{table_name}"

--- a/fractal_tasks_core/replicate_zarr_structure.py
+++ b/fractal_tasks_core/replicate_zarr_structure.py
@@ -25,7 +25,7 @@ from anndata.experimental import write_elem
 from devtools import debug
 
 import fractal_tasks_core
-from .lib_regions_of_interest import convert_FOV_ROIs_3D_to_2D
+from .lib_regions_of_interest import convert_ROIs_from_3D_to_2D
 from .lib_zattrs_utils import extract_zyx_pixel_sizes
 
 
@@ -161,8 +161,11 @@ def replicate_zarr_structure(
                     path_FOV_zattrs, level=0
                 )
                 pxl_size_z = pxl_sizes_zyx[0]
-                FOV_ROI_table = convert_FOV_ROIs_3D_to_2D(
+                FOV_ROI_table = convert_ROIs_from_3D_to_2D(
                     FOV_ROI_table, pxl_size_z
+                )
+                well_ROI_table = convert_ROIs_from_3D_to_2D(
+                    well_ROI_table, pxl_size_z
                 )
 
             # Create table group and write new table

--- a/tests/data/napari_workflows/regionprops.yaml
+++ b/tests/data/napari_workflows/regionprops.yaml
@@ -1,0 +1,12 @@
+!!python/object:napari_workflows._workflow.Workflow
+_tasks:
+  regionprops_DAPI: !!python/tuple
+  - !!python/name:napari_skimage_regionprops._regionprops.regionprops_table ''
+  - dapi_img
+  - label_img
+  - true
+  - true
+  - false
+  - false
+  - false
+  - false

--- a/tests/test_unit_ROI_indices.py
+++ b/tests/test_unit_ROI_indices.py
@@ -2,8 +2,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from fractal_tasks_core.lib_regions_of_interest import convert_FOV_ROIs_3D_to_2D
-from fractal_tasks_core.lib_regions_of_interest import convert_ROI_table_to_indices
+from fractal_tasks_core.lib_regions_of_interest import (
+    convert_ROI_table_to_indices,
+)  # noqa
+from fractal_tasks_core.lib_regions_of_interest import (
+    convert_ROIs_from_3D_to_2D,
+)  # noqa
 from fractal_tasks_core.lib_regions_of_interest import prepare_FOV_ROI_table
 
 
@@ -157,7 +161,7 @@ def test_ROI_indices_2D(level, coarsening_xy, full_res_pxl_sizes_zyx):
 
     metadata_dataframe = get_metadata_dataframe()
     adata = prepare_FOV_ROI_table(metadata_dataframe)
-    adata = convert_FOV_ROIs_3D_to_2D(adata, PIXEL_SIZE_Z)
+    adata = convert_ROIs_from_3D_to_2D(adata, PIXEL_SIZE_Z)
 
     list_indices = convert_ROI_table_to_indices(
         adata,


### PR DESCRIPTION
Closes #103

Several changes were added:
* In measurement.py, change the boolean `whole_well` into the string `ROI_table_name` (and handle this), so that it works both for well or FOVs;
* In measurement.py, rename `table_name` to `measurement_table_name`;
* Rename `convert_FOV_ROIs_3D_to_2D` into `convert_ROIs_from_3D_to_2D`, since it also works for other ROIs (e.g. the well one);
* Skip cellpose in tests, and use `patched_segment_FOV` (this is crucial for CI times);
* Add measurement in `test_workflows.py`, for 3D FOVs;
* Add measurement in `test_workflows.py`, for 2D FOVs;
* Add measurement in `test_workflows.py`, for 2D whole well;
* Correctly handle well table in `replicate_zarr_structure`, when `project_to_2D=True`;