### PR TITLE
Clean up logging

### DIFF
--- a/fractal_tasks_core/create_zarr_structure.py
+++ b/fractal_tasks_core/create_zarr_structure.py
@@ -32,6 +32,11 @@ from .metadata_parsing import parse_yokogawa_metadata
 
 __OME_NGFF_VERSION__ = fractal_tasks_core.__OME_NGFF_VERSION__
 
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 def define_omero_channels(actual_channels, channel_parameters, bit_depth):
 
@@ -159,7 +164,7 @@ def create_zarr_structure(
                 tmp_plates.append(plate)
                 tmp_channels.append(f"A{metadata['A']}_C{metadata['C']}")
             except IndexError:
-                print("IndexError for ", fn)
+                logger.info("IndexError for ", fn)
                 pass
         tmp_plates = sorted(list(set(tmp_plates)))
         tmp_channels = sorted(list(set(tmp_channels)))
@@ -184,7 +189,7 @@ def create_zarr_structure(
             while new_plate in plates:
                 new_plate = f"{plate}_{ind}"
                 ind += 1
-            print(
+            logger.info(
                 f"WARNING: {plate} already exists, renaming it as {new_plate}"
             )
             plates.append(new_plate)
@@ -216,7 +221,7 @@ def create_zarr_structure(
     actual_channels = []
     for ind_ch, ch in enumerate(channels):
         actual_channels.append(ch)
-    print(f"actual_channels: {actual_channels}")
+    logger.info(f"actual_channels: {actual_channels}")
 
     # Clean up dictionary channel_parameters
 
@@ -227,7 +232,7 @@ def create_zarr_structure(
         # Define plate zarr
         zarrurl = f"{plate}.zarr"
         in_path = dict_plate_paths[plate]
-        print(f"Creating {zarrurl}")
+        logger.info(f"Creating {zarrurl}")
         group_plate = zarr.group(output_path.parent / zarrurl)
         zarrurls["plate"].append(zarrurl)
 
@@ -250,7 +255,7 @@ def create_zarr_structure(
                 pixel_size_x = site_metadata["pixel_size_x"][0]
                 bit_depth = site_metadata["bit_depth"][0]
         except FileNotFoundError:
-            print("Missing metadata files")
+            logger.info("Missing metadata files")
             has_mrf_mlf_metadata = False
             pixel_size_x = pixel_size_y = pixel_size_z = 1
 
@@ -279,7 +284,7 @@ def create_zarr_structure(
                     metadata = parse_metadata(os.path.basename(fn))
                     well_channels.append(f"A{metadata['A']}_C{metadata['C']}")
                 except IndexError:
-                    print(f"Skipping {fn}")
+                    logger.info(f"Skipping {fn}")
             well_channels = sorted(list(set(well_channels)))
             if well_channels != actual_channels:
                 raise Exception(

--- a/fractal_tasks_core/dummy.py
+++ b/fractal_tasks_core/dummy.py
@@ -1,9 +1,13 @@
+import logging
 import os
 from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import Optional
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def dummy(
@@ -51,6 +55,8 @@ def dummy(
     import json
     from json.decoder import JSONDecodeError
 
+    logger.info("START of dummy task")
+
     if component:
         index = component
 
@@ -82,5 +88,7 @@ def dummy(
 
     # Update metadata
     metadata_update = {"dummy": "dummy"}
+
+    logger.info("END of dummy task")
 
     return metadata_update

--- a/fractal_tasks_core/illumination_correction.py
+++ b/fractal_tasks_core/illumination_correction.py
@@ -48,7 +48,7 @@ def correct(
     """
 
     if logger is not None:
-        logger.debug("Start correct, {img_stack.shape}")
+        logger.info("Start correct, {img_stack.shape}")
 
     # Check shapes
     if corr_img.shape != img_stack.shape[2:] or img_stack.shape[0] != 1:
@@ -80,7 +80,7 @@ def correct(
         new_img_stack[new_img_stack > dtype_max] = dtype_max
 
     if logger is not None:
-        logger.debug("End correct")
+        logger.info("End correct")
 
     # Cast back to original dtype and return
     return new_img_stack.astype(dtype)

--- a/fractal_tasks_core/illumination_correction.py
+++ b/fractal_tasks_core/illumination_correction.py
@@ -30,6 +30,9 @@ from .lib_pyramid_creation import build_pyramid
 from .lib_regions_of_interest import convert_ROI_table_to_indices
 from .lib_zattrs_utils import extract_zyx_pixel_sizes
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 def correct(
     img_stack: np.ndarray,
@@ -46,7 +49,7 @@ def correct(
 
     """
 
-    logging.info("Start correct, {img_stack.shape}")
+    logger.info("Start correct, {img_stack.shape}")
 
     # Check shapes
     if corr_img.shape != img_stack.shape[2:] or img_stack.shape[0] != 1:
@@ -77,7 +80,7 @@ def correct(
         )
         new_img_stack[new_img_stack > dtype_max] = dtype_max
 
-    logging.info("End correct")
+    logger.info("End correct")
 
     # Cast back to original dtype and return
     return new_img_stack.astype(dtype)
@@ -140,10 +143,10 @@ def illumination_correction(
         zarrurl_new = (output_path.parent / new_component).as_posix()
 
     t_start = time.perf_counter()
-    logging.info("Start illumination_correction")
-    logging.info(f"  {overwrite=}")
-    logging.info(f"  {zarrurl_old=}")
-    logging.info(f"  {zarrurl_new=}")
+    logger.info("Start illumination_correction")
+    logger.info(f"  {overwrite=}")
+    logger.info(f"  {zarrurl_old=}")
+    logger.info(f"  {zarrurl_new=}")
 
     # Read FOV ROIs
     FOV_ROI_table = ad.read_zarr(f"{zarrurl_old}/tables/FOV_ROI_table")
@@ -244,7 +247,7 @@ def illumination_correction(
     )
 
     t_end = time.perf_counter()
-    logging.info(f"End illumination_correction, elapsed: {t_end-t_start}")
+    logger.info(f"End illumination_correction, elapsed: {t_end-t_start}")
 
 
 if __name__ == "__main__":

--- a/fractal_tasks_core/illumination_correction.py
+++ b/fractal_tasks_core/illumination_correction.py
@@ -35,7 +35,6 @@ def correct(
     img_stack: np.ndarray,
     corr_img: np.ndarray,
     background: int = 110,
-    logger: logging.Logger = None,
 ):
     """
     Corrects a stack of images, using a given illumination profile (e.g. bright
@@ -47,8 +46,7 @@ def correct(
 
     """
 
-    if logger is not None:
-        logger.info("Start correct, {img_stack.shape}")
+    logging.info("Start correct, {img_stack.shape}")
 
     # Check shapes
     if corr_img.shape != img_stack.shape[2:] or img_stack.shape[0] != 1:
@@ -79,8 +77,7 @@ def correct(
         )
         new_img_stack[new_img_stack > dtype_max] = dtype_max
 
-    if logger is not None:
-        logger.info("End correct")
+    logging.info("End correct")
 
     # Cast back to original dtype and return
     return new_img_stack.astype(dtype)
@@ -96,7 +93,6 @@ def illumination_correction(
     new_component: str = None,
     dict_corr: dict = None,
     background: int = 100,
-    logger: logging.Logger = None,
 ):
 
     """
@@ -109,9 +105,6 @@ def illumination_correction(
     new_component: myplate_new_name.zarr/B/03/0/
     metadata: {...}
     """
-
-    if logger is None:
-        logger = logging.getLogger(__name__)
 
     # Preliminary checks
     if len(input_paths) > 1:
@@ -147,10 +140,10 @@ def illumination_correction(
         zarrurl_new = (output_path.parent / new_component).as_posix()
 
     t_start = time.perf_counter()
-    logger.info("Start illumination_correction")
-    logger.info(f"  {overwrite=}")
-    logger.info(f"  {zarrurl_old=}")
-    logger.info(f"  {zarrurl_new=}")
+    logging.info("Start illumination_correction")
+    logging.info(f"  {overwrite=}")
+    logging.info(f"  {zarrurl_old=}")
+    logging.info(f"  {zarrurl_new=}")
 
     # Read FOV ROIs
     FOV_ROI_table = ad.read_zarr(f"{zarrurl_old}/tables/FOV_ROI_table")
@@ -232,7 +225,6 @@ def illumination_correction(
                 data_czyx[region].compute(),
                 corrections[channel],
                 background=background,
-                logger=logger,
             )
             # Write to disk
             da.array(corrected_fov).to_zarr(
@@ -252,7 +244,7 @@ def illumination_correction(
     )
 
     t_end = time.perf_counter()
-    logger.info(f"End illumination_correction, elapsed: {t_end-t_start}")
+    logging.info(f"End illumination_correction, elapsed: {t_end-t_start}")
 
 
 if __name__ == "__main__":

--- a/fractal_tasks_core/image_labeling.py
+++ b/fractal_tasks_core/image_labeling.py
@@ -33,6 +33,9 @@ from .lib_regions_of_interest import convert_ROI_table_to_indices
 from .lib_zattrs_utils import extract_zyx_pixel_sizes
 from .lib_zattrs_utils import rescale_datasets
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 __OME_NGFF_VERSION__ = fractal_tasks_core.__OME_NGFF_VERSION__
 
@@ -125,7 +128,7 @@ def image_labeling(
         raise NotImplementedError
     in_path = input_paths[0]
     zarrurl = (in_path.parent.resolve() / component).as_posix() + "/"
-    logging.info(zarrurl)
+    logger.info(zarrurl)
 
     # Read useful parameters from metadata
     num_levels = metadata["num_levels"]
@@ -136,7 +139,7 @@ def image_labeling(
     # Find well ID
     well_ID = well.replace("/", "_")[:-1]
     logfile = f"LOG_image_labeling_{well_ID}"  # FIXME
-    logging.info(well_ID)
+    logger.info(well_ID)
 
     # Find channel index
     if labeling_channel not in chl_list:
@@ -145,7 +148,7 @@ def image_labeling(
 
     # Load ZYX data
     data_zyx = da.from_zarr(f"{zarrurl}{labeling_level}")[ind_channel]
-    logging.info(data_zyx.shape)
+    logger.info(data_zyx.shape)
 
     # Read ROI table
     ROI_table = ad.read_zarr(f"{zarrurl}tables/{ROI_table_name}")
@@ -194,7 +197,7 @@ def image_labeling(
                 zarrurl + ".zattrs", level=labeling_level
             )
             pixel_size_z, pixel_size_y, pixel_size_x = pxl_zyx[:]
-            logging.info(pxl_zyx)
+            logger.info(pxl_zyx)
             if not np.allclose(pixel_size_x, pixel_size_y):
                 raise Exception(
                     "ERROR: XY anisotropy detected\n"
@@ -257,7 +260,7 @@ def image_labeling(
     ]
 
     # Open new zarr group for mask 0-th level
-    logging.info(f"{zarrurl}labels/{label_name}/0")
+    logger.info(f"{zarrurl}labels/{label_name}/0")
     zarr.group(f"{zarrurl}/labels")
     zarr.group(f"{zarrurl}/labels/{label_name}")
     store = da.core.get_mapper(f"{zarrurl}labels/{label_name}/0")

--- a/fractal_tasks_core/image_labeling.py
+++ b/fractal_tasks_core/image_labeling.py
@@ -12,6 +12,7 @@ Institute for Biomedical Research and Pelkmans Lab from the University of
 Zurich.
 """
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any
@@ -25,7 +26,6 @@ import numpy as np
 import zarr
 from cellpose import models
 from cellpose.core import use_gpu
-from devtools import debug
 
 import fractal_tasks_core
 from .lib_pyramid_creation import build_pyramid
@@ -125,7 +125,7 @@ def image_labeling(
         raise NotImplementedError
     in_path = input_paths[0]
     zarrurl = (in_path.parent.resolve() / component).as_posix() + "/"
-    debug(zarrurl)
+    logging.info(zarrurl)
 
     # Read useful parameters from metadata
     num_levels = metadata["num_levels"]
@@ -136,7 +136,7 @@ def image_labeling(
     # Find well ID
     well_ID = well.replace("/", "_")[:-1]
     logfile = f"LOG_image_labeling_{well_ID}"  # FIXME
-    debug(well_ID)
+    logging.info(well_ID)
 
     # Find channel index
     if labeling_channel not in chl_list:
@@ -145,7 +145,7 @@ def image_labeling(
 
     # Load ZYX data
     data_zyx = da.from_zarr(f"{zarrurl}{labeling_level}")[ind_channel]
-    debug(data_zyx.shape)
+    logging.info(data_zyx.shape)
 
     # Read ROI table
     ROI_table = ad.read_zarr(f"{zarrurl}tables/{ROI_table_name}")
@@ -194,7 +194,7 @@ def image_labeling(
                 zarrurl + ".zattrs", level=labeling_level
             )
             pixel_size_z, pixel_size_y, pixel_size_x = pxl_zyx[:]
-            debug(pxl_zyx)
+            logging.info(pxl_zyx)
             if not np.allclose(pixel_size_x, pixel_size_y):
                 raise Exception(
                     "ERROR: XY anisotropy detected\n"
@@ -257,7 +257,7 @@ def image_labeling(
     ]
 
     # Open new zarr group for mask 0-th level
-    debug(f"{zarrurl}labels/{label_name}/0")
+    logging.info(f"{zarrurl}labels/{label_name}/0")
     zarr.group(f"{zarrurl}/labels")
     zarr.group(f"{zarrurl}/labels/{label_name}")
     store = da.core.get_mapper(f"{zarrurl}labels/{label_name}/0")

--- a/fractal_tasks_core/lib_remove_FOV_overlaps.py
+++ b/fractal_tasks_core/lib_remove_FOV_overlaps.py
@@ -1,3 +1,9 @@
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
 def is_overlapping_1D(line1, line2, tol=0):
     """
     Based on https://stackoverflow.com/a/70023212/19085332
@@ -65,7 +71,7 @@ def remove_FOV_overlaps(df):
     # Loop over wells
     wells = sorted(list(set([ind[0] for ind in df.index])))
     for well in wells:
-        print(f"[remove_FOV_overlaps] removing FOV overlaps for {well=}")
+        logger.info(f"removing FOV overlaps for {well=}")
 
         # NOTE: these are positional indices (i.e. starting from 0)
         pair_pos_indices = get_overlapping_pair(
@@ -89,8 +95,8 @@ def remove_FOV_overlaps(df):
                 pos_ind_2
             ]
 
-            print(
-                f"[remove_FOV_overlaps] {iteration=}, removing overlap between"
+            logger.info(
+                f"{iteration=}, removing overlap between"
                 f" {fov_id_1=} and {fov_id_2=}"
             )
 

--- a/fractal_tasks_core/maximum_intensity_projection.py
+++ b/fractal_tasks_core/maximum_intensity_projection.py
@@ -11,6 +11,7 @@ This file is part of Fractal and was originally developed by eXact lab S.r.l.
 Institute for Biomedical Research and Pelkmans Lab from the University of
 Zurich.
 """
+import logging
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -19,7 +20,6 @@ from typing import Optional
 
 import anndata as ad
 import dask.array as da
-from devtools import debug
 
 from .lib_pyramid_creation import build_pyramid
 from .lib_regions_of_interest import convert_ROI_table_to_indices
@@ -57,8 +57,8 @@ def maximum_intensity_projection(
     zarrurl_old = metadata["replicate_zarr"]["sources"][plate] + "/" + well
     clean_output_path = output_path.parent.resolve()
     zarrurl_new = (clean_output_path / component).as_posix()
-    debug(zarrurl_old)
-    debug(zarrurl_new)
+    logging.info(f"{zarrurl_old=}")
+    logging.info(f"{zarrurl_new=}")
 
     # This whole block finds (chunk_size_y,chunk_size_x)
     FOV_ROI_table = ad.read_zarr(f"{zarrurl_old}/tables/FOV_ROI_table")

--- a/fractal_tasks_core/maximum_intensity_projection.py
+++ b/fractal_tasks_core/maximum_intensity_projection.py
@@ -25,6 +25,9 @@ from .lib_pyramid_creation import build_pyramid
 from .lib_regions_of_interest import convert_ROI_table_to_indices
 from .lib_zattrs_utils import extract_zyx_pixel_sizes
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 def maximum_intensity_projection(
     *,
@@ -57,8 +60,8 @@ def maximum_intensity_projection(
     zarrurl_old = metadata["replicate_zarr"]["sources"][plate] + "/" + well
     clean_output_path = output_path.parent.resolve()
     zarrurl_new = (clean_output_path / component).as_posix()
-    logging.info(f"{zarrurl_old=}")
-    logging.info(f"{zarrurl_new=}")
+    logger.info(f"{zarrurl_old=}")
+    logger.info(f"{zarrurl_new=}")
 
     # This whole block finds (chunk_size_y,chunk_size_x)
     FOV_ROI_table = ad.read_zarr(f"{zarrurl_old}/tables/FOV_ROI_table")

--- a/fractal_tasks_core/measurement.py
+++ b/fractal_tasks_core/measurement.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,9 @@ from napari_workflows._io_yaml_v1 import load_workflow
 
 from .lib_regions_of_interest import convert_ROI_table_to_indices
 from .lib_zattrs_utils import extract_zyx_pixel_sizes
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def measurement(
@@ -127,12 +131,11 @@ def measurement(
     # Get the workflow
     napari_workflow = load_workflow(workflow_file)
 
-    print(f"Workflow file:         {workflow_file}")
-    print(f"Resolution level:      {level}")
-    print(f"Labels upscale factor: {upscale_factor}")
-    print(f"Whole-array shape:     {img_shape}")
-    print(f"is_2D:                 {is_2D}")
-    print()
+    logger.info(f"Workflow file:         {workflow_file}")
+    logger.info(f"Resolution level:      {level}")
+    logger.info(f"Labels upscale factor: {upscale_factor}")
+    logger.info(f"Whole-array shape:     {img_shape}")
+    logger.info(f"is_2D:                 {is_2D}")
 
     # Loop over FOV ROIs
     list_dfs = []
@@ -143,7 +146,7 @@ def measurement(
             if not (s_z, e_z) == (0, 1):
                 raise Exception("Something went wrong with 2D ROI ", ROI)
             ROI = (slice(s_y, e_y), slice(s_x, e_x))
-        print(f"Single-ROI shape:      {img[ROI].shape}")
+        logger.info(f"Single-ROI shape:      {img[ROI].shape}")
 
         # Set the input images: DAPI image & label image for current ROI
         napari_workflow.set("dapi_img", img[ROI])

--- a/fractal_tasks_core/replicate_zarr_structure.py
+++ b/fractal_tasks_core/replicate_zarr_structure.py
@@ -28,6 +28,9 @@ import fractal_tasks_core
 from .lib_regions_of_interest import convert_ROIs_from_3D_to_2D
 from .lib_zattrs_utils import extract_zyx_pixel_sizes
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 __OME_NGFF_VERSION__ = fractal_tasks_core.__OME_NGFF_VERSION__
 
@@ -63,7 +66,7 @@ def replicate_zarr_structure(
     list_plates = [
         p.as_posix() for p in in_path.parent.resolve().glob(in_path.name)
     ]
-    logging.info("{list_plates=}")
+    logger.info("{list_plates=}")
 
     meta_update = {"replicate_zarr": {}}
     meta_update["replicate_zarr"]["suffix"] = suffix
@@ -78,9 +81,9 @@ def replicate_zarr_structure(
         zarrurl_new = f"{(new_plate_dir / new_plate_name).as_posix()}.zarr"
         meta_update["replicate_zarr"]["sources"][new_plate_name] = zarrurl_old
 
-        logging.info(f"{zarrurl_old=}")
-        logging.info(f"{zarrurl_new=}")
-        logging.info(f"{meta_update=}")
+        logger.info(f"{zarrurl_old=}")
+        logger.info(f"{zarrurl_new=}")
+        logger.info(f"{meta_update=}")
 
         # Identify properties of input zarr file
         well_rows_columns = sorted(
@@ -97,7 +100,7 @@ def replicate_zarr_structure(
 
         group_plate = zarr.group(zarrurl_new)
         plate = zarrurl_old.replace(".zarr", "").split("/")[-1]
-        logging.info(f"{plate=}")
+        logger.info(f"{plate=}")
         group_plate.attrs["plate"] = {
             "acquisitions": [{"id": 0, "name": plate}],
             "columns": [{"name": col} for col in col_list],

--- a/fractal_tasks_core/replicate_zarr_structure.py
+++ b/fractal_tasks_core/replicate_zarr_structure.py
@@ -12,6 +12,7 @@ Institute for Biomedical Research and Pelkmans Lab from the University of
 Zurich.
 """
 import json
+import logging
 from glob import glob
 from pathlib import Path
 from typing import Any
@@ -22,7 +23,6 @@ from typing import Optional
 import anndata as ad
 import zarr
 from anndata.experimental import write_elem
-from devtools import debug
 
 import fractal_tasks_core
 from .lib_regions_of_interest import convert_ROIs_from_3D_to_2D
@@ -63,7 +63,7 @@ def replicate_zarr_structure(
     list_plates = [
         p.as_posix() for p in in_path.parent.resolve().glob(in_path.name)
     ]
-    debug(list_plates)
+    logging.info("{list_plates=}")
 
     meta_update = {"replicate_zarr": {}}
     meta_update["replicate_zarr"]["suffix"] = suffix
@@ -78,9 +78,9 @@ def replicate_zarr_structure(
         zarrurl_new = f"{(new_plate_dir / new_plate_name).as_posix()}.zarr"
         meta_update["replicate_zarr"]["sources"][new_plate_name] = zarrurl_old
 
-        debug(zarrurl_old)
-        debug(zarrurl_new)
-        debug(meta_update)
+        logging.info(f"{zarrurl_old=}")
+        logging.info(f"{zarrurl_new=}")
+        logging.info(f"{meta_update=}")
 
         # Identify properties of input zarr file
         well_rows_columns = sorted(
@@ -97,7 +97,7 @@ def replicate_zarr_structure(
 
         group_plate = zarr.group(zarrurl_new)
         plate = zarrurl_old.replace(".zarr", "").split("/")[-1]
-        debug(plate)
+        logging.info(f"{plate=}")
         group_plate.attrs["plate"] = {
             "acquisitions": [{"id": 0, "name": plate}],
             "columns": [{"name": col} for col in col_list],

--- a/fractal_tasks_core/yokogawa_to_zarr.py
+++ b/fractal_tasks_core/yokogawa_to_zarr.py
@@ -11,6 +11,7 @@ This file is part of Fractal and was originally developed by eXact lab S.r.l.
 Institute for Biomedical Research and Pelkmans Lab from the University of
 Zurich.
 """
+import logging
 import os
 import re
 from glob import glob
@@ -28,6 +29,9 @@ from dask.array.image import imread
 from .lib_pyramid_creation import build_pyramid
 from .lib_regions_of_interest import convert_ROI_table_to_indices
 from .lib_zattrs_utils import extract_zyx_pixel_sizes
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def sort_fun(s):
@@ -118,7 +122,7 @@ def yokogawa_to_zarr(
         A, C = chl.split("_")
 
         glob_path = f"{in_path}/*_{well_ID}_*{A}*{C}{ext}"
-        print(f"glob path: {glob_path}")
+        logger.info(f"glob path: {glob_path}")
         filenames = sorted(glob(glob_path), key=sort_fun)
         if len(filenames) == 0:
             raise Exception(
@@ -165,7 +169,7 @@ def yokogawa_to_zarr(
             try:
                 os.remove(f)
             except OSError as e:
-                print("Error: %s : %s" % (f, e.strerror))
+                logging.info("Error: %s : %s" % (f, e.strerror))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #117 

We replaced most `debug` and `print` statements with `logger.info`, where each module also includes lines like:
```python
import logging
logging.basicConfig(level=logging.INFO)
logger = logging.getLogger(__name__)
```

With this PR, the `examples/01_cardio_tiny_dataset/run_workflow.py` prints this output (where I am removing output which is not coming from the tasks, but from the actual example script):
```
INFO:fractal_tasks_core.create_zarr_structure:actual_channels: ['A01_C01']
INFO:fractal_tasks_core.create_zarr_structure:Creating 20200812-CardiomyocyteDifferentiation14-Cycle1.zarr
INFO:fractal_tasks_core.lib_remove_FOV_overlaps:removing FOV overlaps for well='B03'
# omitted
INFO:fractal_tasks_core.yokogawa_to_zarr:glob path: ../images/10.5281_zenodo.7059515/*_B03_*A01*C01*.png
# omitted
```
thus including the module name in the log.