### PR TITLE
Refactor Yokogawa metadata parsing

### DIFF
--- a/fractal_tasks_core/metadata_parsing.py
+++ b/fractal_tasks_core/metadata_parsing.py
@@ -33,33 +33,20 @@ def parse_yokogawa_metadata(mrf_path, mlf_path):
     """
     mrf_frame, mlf_frame, error_count = read_metadata_files(mrf_path, mlf_path)
 
+    # Aggregate information from the mlf file
     per_site_parameters = [
-        "x_micrometer",
-        "y_micrometer",
-        "pixel_size_x",
-        "pixel_size_y",
-        "x_pixel",
-        "y_pixel",
-        "bit_depth",
+        "X",
+        "Y"
     ]
-    grouping_params = ["well_id", "field_id"]
+
+    grouping_params = ["well_id", "FieldIndex"]
     grouped_sites = mlf_frame.loc[
-        :, grouping_params + per_site_parameters
-    ].groupby(by=grouping_params)
-    check_grouped_sites_consistency(grouped_sites, per_site_parameters)
+            :, grouping_params + per_site_parameters
+        ].groupby(by=grouping_params)
+
+    check_group_consistency(grouped_sites, message='X & Y stage positions')
     site_metadata = grouped_sites.mean()
-
-    # Cast image pixel sizes & bit depth to int
-    site_metadata = site_metadata.astype(
-        {
-            "x_pixel": "int",
-            "y_pixel": "int",
-            "bit_depth": "int",
-        }
-    )
-
-    # Absolute Z positions are not saved by the Yokogawa,
-    # only relative positions to the autofocus
+    site_metadata.columns = ['x_micrometer', 'y_micrometer']
     site_metadata["z_micrometer"] = 0
 
     site_metadata = pd.concat(
@@ -70,6 +57,20 @@ def parse_yokogawa_metadata(mrf_path, mlf_path):
         ],
         axis=1,
     )
+
+    # Aggregate information from the mrf file
+    mrf_columns = ["horiz_pixel_dim", "vert_pixel_dim", "horiz_pixels", "vert_pixels", "bit_depth"]
+    check_group_consistency(mrf_frame.loc[:, mrf_columns], message='Image dimensions')
+    site_metadata['pixel_size_x'] = mrf_frame.loc[:, "horiz_pixel_dim"].max()
+    site_metadata['pixel_size_y'] = mrf_frame.loc[:, "vert_pixel_dim"].max()
+    site_metadata['x_pixel'] = int(mrf_frame.loc[:, "horiz_pixels"].max())
+    site_metadata['y_pixel'] = int(mrf_frame.loc[:, "vert_pixels"].max())
+    site_metadata['bit_depth'] = int(mrf_frame.loc[:, "bit_depth"].max())
+
+    original_site_metadata = ['x_micrometer', 'y_micrometer', 'pixel_size_x', 'pixel_size_y',
+        'x_pixel', 'y_pixel', 'bit_depth', 'z_micrometer', 'pixel_size_z',
+        'z_pixel', 'time', 'x_micrometer_original', 'y_micrometer_original']
+    site_metadata
 
     if error_count > 0:
         logger.info(
@@ -98,7 +99,7 @@ def read_metadata_files(mrf_path, mlf_path):
     # processed further. Figure out how to save them as relevant metadata for
     # use e.g. during illumination correction
 
-    mlf_frame, error_count = read_mlf_file(mlf_path, mrf_frame)
+    mlf_frame, error_count = read_mlf_file(mlf_path)
     # TODO: Time points are parsed as part of the mlf_frame, but currently not
     # processed further. Once we tackle time-resolved data, parse from here.
 
@@ -142,136 +143,149 @@ def read_mrf_file(mrf_path):
     return mrf_frame
 
 
-def read_mlf_file(mlf_path, mrf_frame):
-    # Docstring TBD
-    mlf_xml = ElementTree.parse(mlf_path).getroot()
-    ns = {"bts": "http://www.yokogawa.co.jp/BTS/BTSSchema/1.0"}
+def read_mlf_file(mlf_path):
+    mlf_frame = pd.read_xml(mlf_path)   
 
-    # Measure number of lines
-    def blocks(fh, size=65536):
-        while True:
-            block = fh.read(size)
-            if not block:
-                break
-            yield block
+    # Create a well ID column
+    row_str = [chr(x) for x in (mlf_frame['Row'] + 64)]
+    mlf_frame['well_id'] = ['{}{:02}'.format(a, b) for a, b in zip(row_str, mlf_frame['Column'])]
 
-    mlf_entries = mlf_xml.findall("bts:MeasurementRecord", namespaces=ns)
-    nb_lines = len(mlf_entries)
-
-    # Prepare mlf dataframe
-    mlf_columns = [
-        "type",
-        "well_id",
-        "column",
-        "row",
-        "time_point",
-        "field_id",
-        "z_index",
-        "timeline_id",
-        "action_id",
-        "action",
-        "x_micrometer",
-        "y_micrometer",
-        "z_micrometer",
-        "x_pixel",
-        "y_pixel",
-        "pixel_size_x",
-        "pixel_size_y",
-        "bit_depth",
-        "width",
-        "height",
-        "channel_id",
-        "camera_no",
-        "file_name",
-        "time",
-    ]
-    mlf_frame = pd.DataFrame(columns=mlf_columns, index=range(0, nb_lines))
-
-    mrf_channel_indices = {
-        row.channel_id: idx
-        for idx, (_, row) in enumerate(mrf_frame.iterrows())
-    }
-
+    # TODO: Implement error handling (& don't parse the error lines to the output) => filter for IMG
     error_count = 0
-    for idx, record in enumerate(mlf_entries):
-        rec_type = record.get("{%s}Type" % ns["bts"])
 
-        if rec_type == "ERR":
-            warnings.warn(
-                "When parsing the yokogawa metadata, "
-                f"found an 'ERR' entry at line '{idx+3}' in the MLF "
-                f"meta file! The error was: '{record.text}'."
-                "The entry is skipped."
-            )
-            error_count += 1
-            continue
-        elif rec_type != "IMG":
-            warnings.warn(
-                "When parsing the yokogawa metadata, "
-                f"Found unexpected '{rec_type}' entry at line '{idx+3}'"
-                "in the MLF meta file! The entry is skipped."
-            )
-            error_count += 1
-            continue
-
-        channel_id = record.get("{%s}Ch" % ns["bts"])
-        x_micrometer = float(record.get("{%s}X" % ns["bts"]))
-        # we mirror the y coordinate to fit with the field layout
-        y_micrometer = -float(record.get("{%s}Y" % ns["bts"]))
-        z_micrometer = float(record.get("{%s}Z" % ns["bts"]))
-
-        well_row_id = record.get("{%s}Row" % ns["bts"])
-        well_col_id = record.get("{%s}Column" % ns["bts"])
-        well_id = chr(64 + int(well_row_id)) + str(well_col_id).zfill(2)
-        # Convert all times to UTC time zone to avoid later timezone handling
-        time = pd.to_datetime(record.get("{%s}Time" % ns["bts"]), utc=True)
-
-        bit_depth = np.nan
-        width = np.nan
-        height = np.nan
-        camera_no = np.nan
-        pixel_size_x = np.nan
-        pixel_size_y = np.nan
-        if rec_type == "IMG":
-            mrf_idx = mrf_channel_indices[channel_id]
-            pixel_size_x = mrf_frame.iat[mrf_idx, 1]
-            pixel_size_y = mrf_frame.iat[mrf_idx, 2]
-            bit_depth = int(mrf_frame.iat[mrf_idx, 4])
-            width = int(mrf_frame.iat[mrf_idx, 5])
-            height = int(mrf_frame.iat[mrf_idx, 6])
-            camera_no = int(mrf_frame.iat[mrf_idx, 3])
-
-        # we use iat[] here for (significant) performance reasons
-        mlf_frame.iat[idx, 0] = rec_type
-        mlf_frame.iat[idx, 1] = well_id
-        mlf_frame.iat[idx, 2] = int(well_col_id)
-        mlf_frame.iat[idx, 3] = int(well_row_id)
-        mlf_frame.iat[idx, 4] = int(record.get("{%s}TimePoint" % ns["bts"]))
-        mlf_frame.iat[idx, 5] = int(record.get("{%s}FieldIndex" % ns["bts"]))
-        mlf_frame.iat[idx, 6] = int(record.get("{%s}ZIndex" % ns["bts"]))
-        mlf_frame.iat[idx, 7] = int(
-            record.get("{%s}TimelineIndex" % ns["bts"])
-        )
-        mlf_frame.iat[idx, 8] = int(record.get("{%s}ActionIndex" % ns["bts"]))
-        mlf_frame.iat[idx, 9] = record.get("{%s}Action" % ns["bts"])
-        mlf_frame.iat[idx, 10] = x_micrometer
-        mlf_frame.iat[idx, 11] = y_micrometer
-        mlf_frame.iat[idx, 12] = z_micrometer
-        mlf_frame.iat[idx, 13] = width
-        mlf_frame.iat[idx, 14] = height
-        mlf_frame.iat[idx, 15] = pixel_size_x
-        mlf_frame.iat[idx, 16] = pixel_size_y
-
-        mlf_frame.iat[idx, 17] = bit_depth
-        mlf_frame.iat[idx, 18] = width
-        mlf_frame.iat[idx, 19] = height
-        mlf_frame.iat[idx, 20] = channel_id
-        mlf_frame.iat[idx, 21] = camera_no
-        mlf_frame.iat[idx, 22] = record.text  # file_name
-        mlf_frame.iat[idx, 23] = time  # file_name
-
-    mlf_frame = mlf_frame.dropna(thresh=(len(mlf_frame.columns)))
     return mlf_frame, error_count
+
+
+# def read_mlf_file_old(mlf_path, mrf_frame):
+#     # Docstring TBD
+#     mlf_xml = ElementTree.parse(mlf_path).getroot()
+#     ns = {"bts": "http://www.yokogawa.co.jp/BTS/BTSSchema/1.0"}
+
+#     # Measure number of lines
+#     def blocks(fh, size=65536):
+#         while True:
+#             block = fh.read(size)
+#             if not block:
+#                 break
+#             yield block
+
+#     mlf_entries = mlf_xml.findall("bts:MeasurementRecord", namespaces=ns)
+#     nb_lines = len(mlf_entries)
+
+#     # Prepare mlf dataframe
+#     mlf_columns = [
+#         "type",
+#         "well_id",
+#         "column",
+#         "row",
+#         "time_point",
+#         "field_id",
+#         "z_index",
+#         "timeline_id",
+#         "action_id",
+#         "action",
+#         "x_micrometer",
+#         "y_micrometer",
+#         "z_micrometer",
+#         "x_pixel",
+#         "y_pixel",
+#         "pixel_size_x",
+#         "pixel_size_y",
+#         "bit_depth",
+#         "width",
+#         "height",
+#         "channel_id",
+#         "camera_no",
+#         "file_name",
+#         "time",
+#     ]
+#     mlf_frame = pd.DataFrame(columns=mlf_columns, index=range(0, nb_lines))
+
+#     mrf_channel_indices = {
+#         row.channel_id: idx
+#         for idx, (_, row) in enumerate(mrf_frame.iterrows())
+#     }
+
+#     error_count = 0
+#     for idx, record in enumerate(mlf_entries):
+#         rec_type = record.get("{%s}Type" % ns["bts"])
+
+#         if rec_type == "ERR":
+#             warnings.warn(
+#                 "When parsing the yokogawa metadata, "
+#                 f"found an 'ERR' entry at line '{idx+3}' in the MLF "
+#                 f"meta file! The error was: '{record.text}'."
+#                 "The entry is skipped."
+#             )
+#             error_count += 1
+#             continue
+#         elif rec_type != "IMG":
+#             warnings.warn(
+#                 "When parsing the yokogawa metadata, "
+#                 f"Found unexpected '{rec_type}' entry at line '{idx+3}'"
+#                 "in the MLF meta file! The entry is skipped."
+#             )
+#             error_count += 1
+#             continue
+
+#         channel_id = record.get("{%s}Ch" % ns["bts"])
+#         x_micrometer = float(record.get("{%s}X" % ns["bts"]))
+#         # we mirror the y coordinate to fit with the field layout
+#         y_micrometer = -float(record.get("{%s}Y" % ns["bts"]))
+#         z_micrometer = float(record.get("{%s}Z" % ns["bts"]))
+
+#         well_row_id = record.get("{%s}Row" % ns["bts"])
+#         well_col_id = record.get("{%s}Column" % ns["bts"])
+#         well_id = chr(64 + int(well_row_id)) + str(well_col_id).zfill(2)
+#         # Convert all times to UTC time zone to avoid later timezone handling
+#         time = pd.to_datetime(record.get("{%s}Time" % ns["bts"]), utc=True)
+
+#         bit_depth = np.nan
+#         width = np.nan
+#         height = np.nan
+#         camera_no = np.nan
+#         pixel_size_x = np.nan
+#         pixel_size_y = np.nan
+#         if rec_type == "IMG":
+#             mrf_idx = mrf_channel_indices[channel_id]
+#             pixel_size_x = mrf_frame.iat[mrf_idx, 1]
+#             pixel_size_y = mrf_frame.iat[mrf_idx, 2]
+#             bit_depth = int(mrf_frame.iat[mrf_idx, 4])
+#             width = int(mrf_frame.iat[mrf_idx, 5])
+#             height = int(mrf_frame.iat[mrf_idx, 6])
+#             camera_no = int(mrf_frame.iat[mrf_idx, 3])
+
+#         # we use iat[] here for (significant) performance reasons
+#         mlf_frame.iat[idx, 0] = rec_type
+#         mlf_frame.iat[idx, 1] = well_id
+#         mlf_frame.iat[idx, 2] = int(well_col_id)
+#         mlf_frame.iat[idx, 3] = int(well_row_id)
+#         mlf_frame.iat[idx, 4] = int(record.get("{%s}TimePoint" % ns["bts"]))
+#         mlf_frame.iat[idx, 5] = int(record.get("{%s}FieldIndex" % ns["bts"]))
+#         mlf_frame.iat[idx, 6] = int(record.get("{%s}ZIndex" % ns["bts"]))
+#         mlf_frame.iat[idx, 7] = int(
+#             record.get("{%s}TimelineIndex" % ns["bts"])
+#         )
+#         mlf_frame.iat[idx, 8] = int(record.get("{%s}ActionIndex" % ns["bts"]))
+#         mlf_frame.iat[idx, 9] = record.get("{%s}Action" % ns["bts"])
+#         mlf_frame.iat[idx, 10] = x_micrometer
+#         mlf_frame.iat[idx, 11] = y_micrometer
+#         mlf_frame.iat[idx, 12] = z_micrometer
+#         mlf_frame.iat[idx, 13] = width
+#         mlf_frame.iat[idx, 14] = height
+#         mlf_frame.iat[idx, 15] = pixel_size_x
+#         mlf_frame.iat[idx, 16] = pixel_size_y
+
+#         mlf_frame.iat[idx, 17] = bit_depth
+#         mlf_frame.iat[idx, 18] = width
+#         mlf_frame.iat[idx, 19] = height
+#         mlf_frame.iat[idx, 20] = channel_id
+#         mlf_frame.iat[idx, 21] = camera_no
+#         mlf_frame.iat[idx, 22] = record.text  # file_name
+#         mlf_frame.iat[idx, 23] = time  # file_name
+
+#     mlf_frame = mlf_frame.dropna(thresh=(len(mlf_frame.columns)))
+#     return mlf_frame, error_count
 
 
 def calculate_steps(site_series: pd.Series):
@@ -296,20 +310,20 @@ def get_z_steps(mlf_frame):
     grouped_sites_z = (
         mlf_frame.loc[
             :,
-            ["well_id", "field_id", "action_id", "channel_id", "z_micrometer"],
+            ["well_id", "FieldIndex", "ActionIndex", "Ch", "Z"],
         ]
-        .set_index(["well_id", "field_id", "action_id", "channel_id"])
+        .set_index(["well_id", "FieldIndex", "ActionIndex", "Ch"])
         .groupby(level=[0, 1, 2, 3])
     )
 
     # If there is only 1 Z step, set the Z spacing to the count of planes => 1
-    if grouped_sites_z.count()["z_micrometer"].max() == 1:
-        z_data = grouped_sites_z.count().groupby(["well_id", "field_id"])
+    if grouped_sites_z.count()["Z"].max() == 1:
+        z_data = grouped_sites_z.count().groupby(["well_id", "FieldIndex"])
     else:
         # Group the whole site (combine channels), because Z steps need to be
         # consistent between channels for OME-Zarr.
         z_data = grouped_sites_z.apply(calculate_steps).groupby(
-            ["well_id", "field_id"]
+            ["well_id", "FieldIndex"]
         )
     
     # Is this necessary? Checking via std is not save towards float imprecisions
@@ -325,11 +339,11 @@ def get_z_steps(mlf_frame):
     # reduce it to one value.
     # Only check if there is more than one channel available
     if any(
-        grouped_sites_z.count().groupby(["well_id", "field_id"]).count() > 1
+        grouped_sites_z.count().groupby(["well_id", "FieldIndex"]).count() > 1
     ):
         if any(
             grouped_sites_z.count()
-            .groupby(["well_id", "field_id"])
+            .groupby(["well_id", "FieldIndex"])
             .std()
             .sum()
             != 0
@@ -341,7 +355,7 @@ def get_z_steps(mlf_frame):
             )
     z_steps = (
         grouped_sites_z.count()
-        .groupby(["well_id", "field_id"])
+        .groupby(["well_id", "FieldIndex"])
         .mean()
         .astype(int)
     )
@@ -352,23 +366,22 @@ def get_z_steps(mlf_frame):
     return z_frame
 
 
-def check_grouped_sites_consistency(grouped_sites, per_site_parameters):
-    # Check that stage positions don't vary within a given site
-    # Same for pixel sizes
-    # Only relevant when a site has multiple entries
-    if grouped_sites.count().min().min() > 1:
-        if not grouped_sites.std().sum().sum() == 0.0:
-            raise Exception(
-                ""
-                "When parsing the Yokogawa MeasurementData.mlf file, "
-                f"some of the parameters {per_site_parameters} varied within "
-                "the site. That is not supported for the OME-Zarr parsing"
-            )
-
-
 def get_earliest_time_per_site(mlf_frame) -> pd.DataFrame:
     # Get the time information per site
     # Because a site will contain time information for each plane
     # of each channel, we just return the earliest time infromation
     # per site.
-    return mlf_frame.groupby(["well_id", "field_id"]).min()["time"]
+    return mlf_frame.groupby(["well_id", "FieldIndex"]).min()["Time"]
+
+
+def check_group_consistency(grouped_df, message=''):
+    # Check consistency in grouped df for multi-index, multi-column dataframes
+    # raises an exception if there is variability
+    diff_df = grouped_df.max() - grouped_df.min()
+    if not np.isclose(np.sum(np.sum(diff_df)), 0.0):
+        raise Exception(
+            'During metadata parsing, a consistency check failed: \n'
+            f'{message}\n'
+            f'Difference dataframe: \n{diff_df}'
+        )
+

--- a/fractal_tasks_core/metadata_parsing.py
+++ b/fractal_tasks_core/metadata_parsing.py
@@ -279,8 +279,8 @@ def calculate_steps(site_series: pd.Series):
     # channel. This function calculates the step size in Z
 
     # First diff is always NaN because there is nothing to compare it to
-    steps = site_series.diff().dropna()
-    if not steps.std().sum() == 0.0:
+    steps = site_series.diff().dropna().astype(float)
+    if not np.allclose(steps.iloc[0], np.array(steps)):
         raise Exception(
             "When parsing the Yokogawa mlf file, some sites "
             "had varying step size in Z. "
@@ -311,12 +311,15 @@ def get_z_steps(mlf_frame):
         z_data = grouped_sites_z.apply(calculate_steps).groupby(
             ["well_id", "field_id"]
         )
-    if not z_data.std().sum().sum() == 0.0:
-        raise Exception(
-            "When parsing the Yokogawa mlf file, channels had "
-            "varying step size in Z. "
-            "That is not supported for the OME-Zarr parsing"
-        )
+    
+    # Is this necessary? Checking via std is not save towards float imprecisions
+    # Thus, deactivated this check for the moment
+    # if not z_data.std().sum().sum() == 0.0:
+    #     raise Exception(
+    #         "When parsing the Yokogawa mlf file, channels had "
+    #         "varying step size in Z. "
+    #         "That is not supported for the OME-Zarr parsing"
+    #     )
 
     # Ensure that channels have the same number of z planes and
     # reduce it to one value.

--- a/poetry.lock
+++ b/poetry.lock
@@ -145,7 +145,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "autopep8"
@@ -302,7 +302,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -599,7 +599,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imagecodecs"
-version = "2022.8.8"
+version = "2022.9.26"
 description = "Image transformation, compression, and decompression codecs"
 category = "main"
 optional = false
@@ -752,7 +752,7 @@ notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
-test_extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
+test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
 name = "ipython-genutils"
@@ -886,6 +886,20 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "lxml"
+version = "4.9.1"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
+source = ["Cython (>=0.29.7)"]
+
+[[package]]
 name = "magicgui"
 version = "0.5.1"
 description = "build GUIs from functions, using magic"
@@ -995,8 +1009,8 @@ wrapt = ">=1.11.1"
 [package.extras]
 all = ["PyQt5 (>=5.12.3,!=5.15.0)", "scikit-image[data]"]
 build = ["black", "isort", "pyqt5"]
-bundle_build = ["PySide2 (==5.15.2)", "briefcase (==0.3.1)", "dmgbuild (>=1.4.2)", "markupsafe (<2.1)", "ruamel.yaml", "tomlkit", "wheel"]
-bundle_run = ["PySide2 (==5.15.2)", "imagecodecs", "numpy (==1.19.3)", "pims", "pip", "scikit-image[data]", "wheel", "zarr"]
+bundle-build = ["PySide2 (==5.15.2)", "briefcase (==0.3.1)", "dmgbuild (>=1.4.2)", "markupsafe (<2.1)", "ruamel.yaml", "tomlkit", "wheel"]
+bundle-run = ["PySide2 (==5.15.2)", "imagecodecs", "numpy (==1.19.3)", "pims", "pip", "scikit-image[data]", "wheel", "zarr"]
 dev = ["PyQt5 (>=5.12.3,!=5.15.0)", "babel (>=2.9.0)", "black (==20.8b1)", "check-manifest (>=0.42)", "flake8 (==3.8.4)", "fsspec", "hypothesis (>=6.8.0)", "lxml", "matplotlib", "meshzoo", "pooch (>=1.3.0)", "pre-commit (>=2.9.0)", "pydantic[dotenv]", "pytest (>=7.0.0)", "pytest-order", "pytest-qt", "rich", "scikit-image[data]", "semgrep", "tensorstore (>=0.1.13)", "torch (>=1.7)", "xarray", "zarr"]
 docs = ["Jinja2", "PyQt5 (>=5.12.3,!=5.15.0)", "jupytext", "lxml", "myst-nb", "napari-sphinx-theme", "scikit-image[data]", "sphinx-autodoc-typehints (==1.12.0)", "sphinx-external-toc", "sphinx-panels", "sphinx-tabs"]
 optional = ["triangle"]
@@ -1744,7 +1758,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
@@ -1977,8 +1991,8 @@ typing-extensions = "*"
 
 [package.extras]
 dev = ["ipython", "isort", "jedi (<0.18.0)", "mypy", "pre-commit", "pyside2", "pytest", "pytest-cov", "pytest-qt", "tox", "tox-conda"]
-font_fa5 = ["fonticon-fontawesome5"]
-font_mi5 = ["fonticon-materialdesignicons5"]
+font-fa5 = ["fonticon-fontawesome5"]
+font-mi5 = ["fonticon-materialdesignicons5"]
 pyqt5 = ["pyqt5"]
 pyqt6 = ["pyqt6"]
 pyside2 = ["pyside2"]
@@ -2233,7 +2247,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0b326c85d3e0d9ccd9a63edb405f83628f51102f6395d61591833744024260d8"
+content-hash = "a63ff6c77f3d3e82f42b2e73be3ff61c4152bf1ac1798f9112aa1f8cb9dc7679"
 
 [metadata.files]
 aiobotocore = [
@@ -2748,25 +2762,25 @@ idna = [
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
 imagecodecs = [
-    {file = "imagecodecs-2022.8.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd2cad4333948e640a298e85d523d1a0d28f7c7878b728f1ece7760a4097cb07"},
-    {file = "imagecodecs-2022.8.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:232a68341907d3f32cd0afdafbc85170397b4d4618adf101c19d2f94e60c0231"},
-    {file = "imagecodecs-2022.8.8-cp310-cp310-win32.whl", hash = "sha256:3f6c77f3462023e423df5b9893ce0462e0abfff32e4e166077d86aee54bc5f70"},
-    {file = "imagecodecs-2022.8.8-cp310-cp310-win_amd64.whl", hash = "sha256:c099bc29a8de2d909255be77e1491c17c057f24fa768f6413202b3b54eb405d9"},
-    {file = "imagecodecs-2022.8.8-cp311-cp311-win32.whl", hash = "sha256:d075c5937b03d92a62ca57e7870816b359890e10610cf33a37bc397cb1d21794"},
-    {file = "imagecodecs-2022.8.8-cp311-cp311-win_amd64.whl", hash = "sha256:82691f8431abdcacdd6718b1e5497e90c854ed984e12591ec7fc25331ae353f8"},
-    {file = "imagecodecs-2022.8.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bb8e1c71fdaff8e40b858d0d42010308e276657c2934eeb42972e4ebc938efd8"},
-    {file = "imagecodecs-2022.8.8-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d307fd847da3ef6aae37d9474755425ddf63d7ff33f153af189b25e292a92c6"},
-    {file = "imagecodecs-2022.8.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74d83b148949265c408ad2e252146f58a9fbbbe8c2e222cba63af10c8c7b0bac"},
-    {file = "imagecodecs-2022.8.8-cp38-cp38-win32.whl", hash = "sha256:5de78cb68865bbd1601981980a9bb2032022fdc4b40b4fb94f3ddea4eb5d4b10"},
-    {file = "imagecodecs-2022.8.8-cp38-cp38-win_amd64.whl", hash = "sha256:97079f7854acb7ac6abc05b098e1d270fc5a08e3e6c0f7cc7ea8a2caf952bb9b"},
-    {file = "imagecodecs-2022.8.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3bf8d87f40f9a0903d68fbe3867c938d261144c6cf9ec9e6844dfe1adc090f97"},
-    {file = "imagecodecs-2022.8.8-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4848cc50aa936f59576acaa124c4fefd8b170aded7e506301df6ca6d23fdad5a"},
-    {file = "imagecodecs-2022.8.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c631b54b977601dfe23995e0b0e21d2620ecbb145d31ad5f10e9d919fc42e0"},
-    {file = "imagecodecs-2022.8.8-cp39-cp39-win32.whl", hash = "sha256:898ccc52204ca814dfe6d0139cada1a2cd2bd5a76b65bc686525109fb0dcdfed"},
-    {file = "imagecodecs-2022.8.8-cp39-cp39-win_amd64.whl", hash = "sha256:6a3029f3de9b46c27a3ca0d115f001256e5c9915204bc72677368e99908b4477"},
-    {file = "imagecodecs-2022.8.8-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eadc5297d50799f216f52e7bf9ff20e6e1b9ee5dd535fd19bf2e652519ac1415"},
-    {file = "imagecodecs-2022.8.8-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:4fb847c32f5d70527c07cc2a552d74318c52f8b2b2152c0465f32a66d5e2122d"},
-    {file = "imagecodecs-2022.8.8.tar.gz", hash = "sha256:507272dd84bf4fbdb25eab5ece76f77442b0d54cf74cf8619f1a0fcc8ac6ceb6"},
+    {file = "imagecodecs-2022.9.26-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8dd5ffb3b37486fd621ebd1c27ce2f0f5936711d736e8b00cb3d8b3a6f484ae"},
+    {file = "imagecodecs-2022.9.26-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d0f397e86fe731f845a7845769d91e49062562b88f09c9cf982e4534c4237c3"},
+    {file = "imagecodecs-2022.9.26-cp310-cp310-win32.whl", hash = "sha256:b3222cb01e9764fcccf90e21920ee76ccf36a4dd1e69d7a7824f9956d2173324"},
+    {file = "imagecodecs-2022.9.26-cp310-cp310-win_amd64.whl", hash = "sha256:f9f02ae0addba6c5305c928d8ef91462cb682c038e6b93021144f53825fb9031"},
+    {file = "imagecodecs-2022.9.26-cp311-cp311-win32.whl", hash = "sha256:7069e0a79dcfab894ebb36dca894bf31db9125d2ded311db76aff69d1bb0440c"},
+    {file = "imagecodecs-2022.9.26-cp311-cp311-win_amd64.whl", hash = "sha256:871ac92eae3387e3dbfefeaff54c4e70b8110c928423673127d0ee268eb061e2"},
+    {file = "imagecodecs-2022.9.26-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:dac006c5bf94a50623061110c1c43fbc2dda8fa631cae41601ebaf354e066440"},
+    {file = "imagecodecs-2022.9.26-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dcc0b47f1e9664fbbf7eca7e83f3472540bb28a89cfa43178712d2c581d2dd48"},
+    {file = "imagecodecs-2022.9.26-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:376461b2255511a3cb5cb68160fda0e44aa77802cb4f44ef980e849121fcd34c"},
+    {file = "imagecodecs-2022.9.26-cp38-cp38-win32.whl", hash = "sha256:49860ac98e6721eb43e799da9682fb5835d183f62d9fc22aff52731f1a3031c4"},
+    {file = "imagecodecs-2022.9.26-cp38-cp38-win_amd64.whl", hash = "sha256:d0b2944ccea7d552b7158bc160fd7a48756e4e72d00a8ee9229a6b993f822fa3"},
+    {file = "imagecodecs-2022.9.26-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:858f78f707f36f34118b3a6a2fba27b718c9c52ea6bda2c68da3a8239a3ed7dc"},
+    {file = "imagecodecs-2022.9.26-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea3c19a75d1d7d129bbe6590eacbd04a1a97888d5064fe96befd04e42368b748"},
+    {file = "imagecodecs-2022.9.26-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80c1e36aad2b105b69e63cd93bf25dbd391e939fe9e4a1f5701aa4bdc0f45330"},
+    {file = "imagecodecs-2022.9.26-cp39-cp39-win32.whl", hash = "sha256:f9ee64055fc5a0ce2cff11aeb0a4f229dca5cd03197a872d8fae1c443f0ff9ae"},
+    {file = "imagecodecs-2022.9.26-cp39-cp39-win_amd64.whl", hash = "sha256:9c521bbd689c3cf4da43e0ea4559e38d58d8a7bcdf8c10b2f0bb7950128abf44"},
+    {file = "imagecodecs-2022.9.26-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b5329ab1618403ba745c8f697dad9ab96459f91f322e855b71103e7d136d765"},
+    {file = "imagecodecs-2022.9.26-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:9c75c38203a0fbf19fb43d619e423f7200cac819066fe6579f7fc57f8c878805"},
+    {file = "imagecodecs-2022.9.26.tar.gz", hash = "sha256:04d5757d8fd7819844b0f8d9eed05025dca4962f280d0010b42c7c9c993fe371"},
 ]
 imageio = [
     {file = "imageio-2.21.3-py3-none-any.whl", hash = "sha256:f8ada7a1cab07a4c437c3367bac271ff3010cf71275955825a5cde778543ca52"},
@@ -2939,6 +2953,78 @@ llvmlite = [
 locket = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
     {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
+]
+lxml = [
+    {file = "lxml-4.9.1-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:98cafc618614d72b02185ac583c6f7796202062c41d2eeecdf07820bad3295ed"},
+    {file = "lxml-4.9.1-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c62e8dd9754b7debda0c5ba59d34509c4688f853588d75b53c3791983faa96fc"},
+    {file = "lxml-4.9.1-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:21fb3d24ab430fc538a96e9fbb9b150029914805d551deeac7d7822f64631dfc"},
+    {file = "lxml-4.9.1-cp27-cp27m-win32.whl", hash = "sha256:86e92728ef3fc842c50a5cb1d5ba2bc66db7da08a7af53fb3da79e202d1b2cd3"},
+    {file = "lxml-4.9.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4cfbe42c686f33944e12f45a27d25a492cc0e43e1dc1da5d6a87cbcaf2e95627"},
+    {file = "lxml-4.9.1-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dad7b164905d3e534883281c050180afcf1e230c3d4a54e8038aa5cfcf312b84"},
+    {file = "lxml-4.9.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a614e4afed58c14254e67862456d212c4dcceebab2eaa44d627c2ca04bf86837"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:f9ced82717c7ec65a67667bb05865ffe38af0e835cdd78728f1209c8fffe0cad"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:d9fc0bf3ff86c17348dfc5d322f627d78273eba545db865c3cd14b3f19e57fa5"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:e5f66bdf0976ec667fc4594d2812a00b07ed14d1b44259d19a41ae3fff99f2b8"},
+    {file = "lxml-4.9.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8"},
+    {file = "lxml-4.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8caf4d16b31961e964c62194ea3e26a0e9561cdf72eecb1781458b67ec83423d"},
+    {file = "lxml-4.9.1-cp310-cp310-win32.whl", hash = "sha256:4780677767dd52b99f0af1f123bc2c22873d30b474aa0e2fc3fe5e02217687c7"},
+    {file = "lxml-4.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:b122a188cd292c4d2fcd78d04f863b789ef43aa129b233d7c9004de08693728b"},
+    {file = "lxml-4.9.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:be9eb06489bc975c38706902cbc6888f39e946b81383abc2838d186f0e8b6a9d"},
+    {file = "lxml-4.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:f1be258c4d3dc609e654a1dc59d37b17d7fef05df912c01fc2e15eb43a9735f3"},
+    {file = "lxml-4.9.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:927a9dd016d6033bc12e0bf5dee1dde140235fc8d0d51099353c76081c03dc29"},
+    {file = "lxml-4.9.1-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9232b09f5efee6a495a99ae6824881940d6447debe272ea400c02e3b68aad85d"},
+    {file = "lxml-4.9.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:04da965dfebb5dac2619cb90fcf93efdb35b3c6994fea58a157a834f2f94b318"},
+    {file = "lxml-4.9.1-cp35-cp35m-win32.whl", hash = "sha256:4d5bae0a37af799207140652a700f21a85946f107a199bcb06720b13a4f1f0b7"},
+    {file = "lxml-4.9.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4878e667ebabe9b65e785ac8da4d48886fe81193a84bbe49f12acff8f7a383a4"},
+    {file = "lxml-4.9.1-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:1355755b62c28950f9ce123c7a41460ed9743c699905cbe664a5bcc5c9c7c7fb"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:bcaa1c495ce623966d9fc8a187da80082334236a2a1c7e141763ffaf7a405067"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eafc048ea3f1b3c136c71a86db393be36b5b3d9c87b1c25204e7d397cee9536"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:13c90064b224e10c14dcdf8086688d3f0e612db53766e7478d7754703295c7c8"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:206a51077773c6c5d2ce1991327cda719063a47adc02bd703c56a662cdb6c58b"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e8f0c9d65da595cfe91713bc1222af9ecabd37971762cb830dea2fc3b3bb2acf"},
+    {file = "lxml-4.9.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8f0a4d179c9a941eb80c3a63cdb495e539e064f8054230844dcf2fcb812b71d3"},
+    {file = "lxml-4.9.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:830c88747dce8a3e7525defa68afd742b4580df6aa2fdd6f0855481e3994d391"},
+    {file = "lxml-4.9.1-cp36-cp36m-win32.whl", hash = "sha256:1e1cf47774373777936c5aabad489fef7b1c087dcd1f426b621fda9dcc12994e"},
+    {file = "lxml-4.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:5974895115737a74a00b321e339b9c3f45c20275d226398ae79ac008d908bff7"},
+    {file = "lxml-4.9.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:1423631e3d51008871299525b541413c9b6c6423593e89f9c4cfbe8460afc0a2"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:2aaf6a0a6465d39b5ca69688fce82d20088c1838534982996ec46633dc7ad6cc"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:9f36de4cd0c262dd9927886cc2305aa3f2210db437aa4fed3fb4940b8bf4592c"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ae06c1e4bc60ee076292e582a7512f304abdf6c70db59b56745cca1684f875a4"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:57e4d637258703d14171b54203fd6822fda218c6c2658a7d30816b10995f29f3"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6d279033bf614953c3fc4a0aa9ac33a21e8044ca72d4fa8b9273fe75359d5cca"},
+    {file = "lxml-4.9.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a60f90bba4c37962cbf210f0188ecca87daafdf60271f4c6948606e4dabf8785"},
+    {file = "lxml-4.9.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:6ca2264f341dd81e41f3fffecec6e446aa2121e0b8d026fb5130e02de1402785"},
+    {file = "lxml-4.9.1-cp37-cp37m-win32.whl", hash = "sha256:27e590352c76156f50f538dbcebd1925317a0f70540f7dc8c97d2931c595783a"},
+    {file = "lxml-4.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:eea5d6443b093e1545ad0210e6cf27f920482bfcf5c77cdc8596aec73523bb7e"},
+    {file = "lxml-4.9.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:f05251bbc2145349b8d0b77c0d4e5f3b228418807b1ee27cefb11f69ed3d233b"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:487c8e61d7acc50b8be82bda8c8d21d20e133c3cbf41bd8ad7eb1aaeb3f07c97"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:8d1a92d8e90b286d491e5626af53afef2ba04da33e82e30744795c71880eaa21"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:b570da8cd0012f4af9fa76a5635cd31f707473e65a5a335b186069d5c7121ff2"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ef87fca280fb15342726bd5f980f6faf8b84a5287fcc2d4962ea8af88b35130"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:93e414e3206779ef41e5ff2448067213febf260ba747fc65389a3ddaa3fb8715"},
+    {file = "lxml-4.9.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6653071f4f9bac46fbc30f3c7838b0e9063ee335908c5d61fb7a4a86c8fd2036"},
+    {file = "lxml-4.9.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:32a73c53783becdb7eaf75a2a1525ea8e49379fb7248c3eeefb9412123536387"},
+    {file = "lxml-4.9.1-cp38-cp38-win32.whl", hash = "sha256:1a7c59c6ffd6ef5db362b798f350e24ab2cfa5700d53ac6681918f314a4d3b94"},
+    {file = "lxml-4.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:1436cf0063bba7888e43f1ba8d58824f085410ea2025befe81150aceb123e345"},
+    {file = "lxml-4.9.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:4beea0f31491bc086991b97517b9683e5cfb369205dac0148ef685ac12a20a67"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:41fb58868b816c202e8881fd0f179a4644ce6e7cbbb248ef0283a34b73ec73bb"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:bd34f6d1810d9354dc7e35158aa6cc33456be7706df4420819af6ed966e85448"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:edffbe3c510d8f4bf8640e02ca019e48a9b72357318383ca60e3330c23aaffc7"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d949f53ad4fc7cf02c44d6678e7ff05ec5f5552b235b9e136bd52e9bf730b91"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:079b68f197c796e42aa80b1f739f058dcee796dc725cc9a1be0cdb08fc45b000"},
+    {file = "lxml-4.9.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9c3a88d20e4fe4a2a4a84bf439a5ac9c9aba400b85244c63a1ab7088f85d9d25"},
+    {file = "lxml-4.9.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4e285b5f2bf321fc0857b491b5028c5f276ec0c873b985d58d7748ece1d770dd"},
+    {file = "lxml-4.9.1-cp39-cp39-win32.whl", hash = "sha256:ef72013e20dd5ba86a8ae1aed7f56f31d3374189aa8b433e7b12ad182c0d2dfb"},
+    {file = "lxml-4.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:10d2017f9150248563bb579cd0d07c61c58da85c922b780060dcc9a3aa9f432d"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538747a9d7827ce3e16a8fdd201a99e661c7dee3c96c885d8ecba3c35d1032c"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:0645e934e940107e2fdbe7c5b6fb8ec6232444260752598bc4d09511bd056c0b"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6daa662aba22ef3258934105be2dd9afa5bb45748f4f702a3b39a5bf53a1f4dc"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-macosx_10_15_x86_64.whl", hash = "sha256:603a464c2e67d8a546ddaa206d98e3246e5db05594b97db844c2f0a1af37cf5b"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c4b2e0559b68455c085fb0f6178e9752c4be3bba104d6e881eb5573b399d1eb2"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0f3f0059891d3254c7b5fb935330d6db38d6519ecd238ca4fce93c234b4a0f73"},
+    {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c852b1530083a620cb0de5f3cd6826f19862bafeaf77586f1aef326e49d95f0c"},
+    {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:287605bede6bd36e930577c5925fcea17cb30453d96a7b4c63c14a257118dbb9"},
+    {file = "lxml-4.9.1.tar.gz", hash = "sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"},
 ]
 magicgui = [
     {file = "magicgui-0.5.1-py2.py3-none-any.whl", hash = "sha256:a87c0c2d068e784e6b49b32b98b0728c1692204a9a15d89f47959a0bb6ee7e39"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ PyQt5 = "^5.15.7"
 anndata = "^0.8.0"
 llvmlite = "^0.39.1"
 imageio-ffmpeg = "^0.4.7"
+lxml = "^4.9.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.2"

--- a/tests/test_unit_parse_yokogawa_metadata.py
+++ b/tests/test_unit_parse_yokogawa_metadata.py
@@ -144,7 +144,7 @@ def test_parse_yokogawa_metadata(
     x_pixel,
     y_pixel,
     bit_depth,
-    time,
+    Time,
 ):
     site_metadata, total_files = parse_yokogawa_metadata(mrf_path, mlf_path)
     assert total_files == expected_files
@@ -158,4 +158,4 @@ def test_parse_yokogawa_metadata(
     assert np.allclose(site_metadata["x_pixel"], x_pixel)
     assert np.allclose(site_metadata["y_pixel"], y_pixel)
     assert np.allclose(site_metadata["bit_depth"], bit_depth)
-    assert list(site_metadata["time"]) == time
+    assert list(site_metadata["time"]) == Time

--- a/tests/test_unit_parse_yokogawa_metadata.py
+++ b/tests/test_unit_parse_yokogawa_metadata.py
@@ -127,7 +127,7 @@ parameters = [
 @pytest.mark.parametrize(
     "mlf_path, mrf_path, expected_files, expected_shape, x_mic_pos, "
     "y_mic_pos, pixel_size_z, z_pixel, pixel_size_x, pixel_size_y, "
-    "x_pixel, y_pixel, bit_depth, time",
+    "x_pixel, y_pixel, bit_depth, Time",
     parameters,
 )
 def test_parse_yokogawa_metadata(

--- a/tests/test_unit_parse_yokogawa_metadata.py
+++ b/tests/test_unit_parse_yokogawa_metadata.py
@@ -158,4 +158,4 @@ def test_parse_yokogawa_metadata(
     assert np.allclose(site_metadata["x_pixel"], x_pixel)
     assert np.allclose(site_metadata["y_pixel"], y_pixel)
     assert np.allclose(site_metadata["bit_depth"], bit_depth)
-    assert list(site_metadata["time"]) == Time
+    assert list(site_metadata["Time"]) == Time


### PR DESCRIPTION
https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/109 can be fixed by changing how the comparison of Z steps is made. The prior approach was not stable when the step sizes varied by tiny amounts due to float imprecision.

I deactivated a second check that used the same approach of measuring standard-deviation of values, as this may also have issues with float imprecisions in some edge cases. Not convinced this check is actually necessary and don't know yet how we'd implement this safely, so it's just off for the moment.