### PR TITLE
Upate arguments of `illumination_correction`` (close #414)

### DIFF
--- a/tests/data/illumination_correction/illum.json
+++ b/tests/data/illumination_correction/illum.json
@@ -1,5 +1,0 @@
-{
-"root_path_corr": "tests/data/illumination_correction",
-"A01_C01": "illum_corr_matrix.png",
-"A02_C02": "illum_corr_matrix.png"
-}

--- a/tests/tasks/test_unit_illumination_correction.py
+++ b/tests/tasks/test_unit_illumination_correction.py
@@ -48,7 +48,6 @@ def test_illumination_correction(
     zarr_path = str(tmp_path)
     testdata_str = testdata_path.as_posix()
     illum_params = {
-        "root_path_corr": f"{testdata_str}/illumination_correction/",
         "A01_C01": "illum_corr_matrix.png",
         "A01_C02": "illum_corr_matrix.png",
     }
@@ -96,6 +95,7 @@ def test_illumination_correction(
             metadata=metadata,
             component=component,
             overwrite=overwrite,
+            root_path_corr=f"{testdata_str}/illumination_correction/",
             dict_corr=illum_params,
             background=0,
         )

--- a/tests/tasks/test_workflows.py
+++ b/tests/tasks/test_workflows.py
@@ -314,7 +314,6 @@ def test_illumination_correction(
 
     testdata_str = testdata_path.as_posix()
     illum_params = {
-        "root_path_corr": f"{testdata_str}/illumination_correction/",
         "A01_C01": "illum_corr_matrix.png",
     }
 
@@ -352,6 +351,7 @@ def test_illumination_correction(
             metadata=metadata,
             component=component,
             overwrite=True,
+            root_path_corr=f"{testdata_str}/illumination_correction/",
             dict_corr=illum_params,
         )
     print(caplog.text)


### PR DESCRIPTION
1. Extract `root_path_corr` from `dict_corr`;
2. Use `pathlib.Path` instead of adding trailing `/` by hand;
3. Update tests.