### PR TITLE
Update `metadata_table` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
     * Create new `dev` subpackage (\#384).
     * Make tasks-related dependencies optional, and installable via `fractal-tasks` extra (\#390).
     * Remove `tools` package extra (\#384), and split the subpackage content into `lib_ROI_overlaps` and `examples` (\#390).
-* Introduce Pydantic models for task arguments (\#410, \#422):
-    * `lib_channels.OmeroChannel` (\#410, \#422);
-    * `tasks._input_models.Channel` (\#422);
-    * `tasks._input_models.NapariWorkflowsInput` (\#422);
-    * `tasks._input_models.NapariWorkflowsOutput` (\#422).
-* Modify arguments of `illumination_correction` task (\#431).
+* **(major)** Modify task arguments
+    * Add Pydantic model `lib_channels.OmeroChannel` (\#410, \#422);
+    * Add Pydantic model `tasks._input_models.Channel` (\#422);
+    * Add Pydantic model `tasks._input_models.NapariWorkflowsInput` (\#422);
+    * Add Pydantic model `tasks._input_models.NapariWorkflowsOutput` (\#422);
+    * Modify arguments of `illumination_correction` task (\#431);
+    * Modify arguments of `create_ome_zarr` and `create_ome_zarr_multiplex` (\#...).
 * JSON Schemas for task arguments:
     * Add JSON schemas for task arguments in the package manifest (\#369, \#384).
     * Remove `TaskArguments` models and switch to Pydantic V1 `validate_arguments` (\#369).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     * Add Pydantic model `tasks._input_models.NapariWorkflowsInput` (\#422);
     * Add Pydantic model `tasks._input_models.NapariWorkflowsOutput` (\#422);
     * Modify arguments of `illumination_correction` task (\#431);
-    * Modify arguments of `create_ome_zarr` and `create_ome_zarr_multiplex` (\#...).
+    * Modify arguments of `create_ome_zarr` and `create_ome_zarr_multiplex` (\#433).
 * JSON Schemas for task arguments:
     * Add JSON schemas for task arguments in the package manifest (\#369, \#384).
     * Remove `TaskArguments` models and switch to Pydantic V1 `validate_arguments` (\#369).


### PR DESCRIPTION
A bunch of commits related to #432 went straight to `main`, by mistake:
* 16d7f0ea9877497ec09520d3ca8779224b129435
* 891e79a87550e765d06ca69915466780ec28dc68
* 7dd98abb8e32ea921cb42a6cc2b4cb5b13199eb6
* 2fc740c580c13e097f38c1d7793fc8a29c9ac54e
* bad28d235bf04185e9f946282848b430224a1b4e

This is a dummy PR, to create a consistent entry in the CHANGELOG and close #432.