### PR TITLE
Update pydantic model docstrings

### DIFF
--- a/fractal_tasks_core/__FRACTAL_MANIFEST__.json
+++ b/fractal_tasks_core/__FRACTAL_MANIFEST__.json
@@ -119,7 +119,7 @@
               "index": {
                 "title": "Index",
                 "type": "integer",
-                "description": "Do not change. For internal use only. "
+                "description": "Do not change. For internal use only."
               },
               "label": {
                 "title": "Label",
@@ -868,7 +868,7 @@
               "index": {
                 "title": "Index",
                 "type": "integer",
-                "description": "Do not change. For internal use only. "
+                "description": "Do not change. For internal use only."
               },
               "label": {
                 "title": "Label",

--- a/fractal_tasks_core/__FRACTAL_MANIFEST__.json
+++ b/fractal_tasks_core/__FRACTAL_MANIFEST__.json
@@ -88,7 +88,7 @@
               "max": {
                 "title": "Max",
                 "type": "integer",
-                "description": "Do not change. It will be set according to bit-depth of the images by\n    default (e.g. 65535 for 16 bit images)."
+                "description": "Do not change. It will be set according to bit-depth of the images by     default (e.g. 65535 for 16 bit images)."
               },
               "start": {
                 "title": "Start",
@@ -128,12 +128,12 @@
               },
               "window": {
                 "$ref": "#/definitions/Window",
-                "description": "Optional ``Window`` object to set default display settings for\n    napari."
+                "description": "Optional ``Window`` object to set default display settings for     napari."
               },
               "color": {
                 "title": "Color",
                 "type": "string",
-                "description": "Optional hex colormap to display the channel in napari\n    (e.g. ``00FFFF``)."
+                "description": "Optional hex colormap to display the channel in napari     (e.g. ``00FFFF``)."
               },
               "active": {
                 "title": "Active",
@@ -837,7 +837,7 @@
               "max": {
                 "title": "Max",
                 "type": "integer",
-                "description": "Do not change. It will be set according to bit-depth of the images by\n    default (e.g. 65535 for 16 bit images)."
+                "description": "Do not change. It will be set according to bit-depth of the images by     default (e.g. 65535 for 16 bit images)."
               },
               "start": {
                 "title": "Start",
@@ -877,12 +877,12 @@
               },
               "window": {
                 "$ref": "#/definitions/Window",
-                "description": "Optional ``Window`` object to set default display settings for\n    napari."
+                "description": "Optional ``Window`` object to set default display settings for     napari."
               },
               "color": {
                 "title": "Color",
                 "type": "string",
-                "description": "Optional hex colormap to display the channel in napari\n    (e.g. ``00FFFF``)."
+                "description": "Optional hex colormap to display the channel in napari     (e.g. ``00FFFF``)."
               },
               "active": {
                 "title": "Active",

--- a/fractal_tasks_core/__FRACTAL_MANIFEST__.json
+++ b/fractal_tasks_core/__FRACTAL_MANIFEST__.json
@@ -88,7 +88,7 @@
               "max": {
                 "title": "Max",
                 "type": "integer",
-                "description": "Do not change. It will be set according to bit-depth of the images by     default (e.g. 65535 for 16 bit images)."
+                "description": "Do not change. It will be set according to bit-depth of the images by default (e.g. 65535 for 16 bit images)."
               },
               "start": {
                 "title": "Start",
@@ -128,12 +128,12 @@
               },
               "window": {
                 "$ref": "#/definitions/Window",
-                "description": "Optional ``Window`` object to set default display settings for     napari."
+                "description": "Optional ``Window`` object to set default display settings for napari."
               },
               "color": {
                 "title": "Color",
                 "type": "string",
-                "description": "Optional hex colormap to display the channel in napari     (e.g. ``00FFFF``)."
+                "description": "Optional hex colormap to display the channel in napari (e.g. ``00FFFF``)."
               },
               "active": {
                 "title": "Active",
@@ -368,7 +368,7 @@
           },
           "channel2": {
             "$ref": "#/definitions/Channel",
-            "description": "Second channel for segmentation (in the same format as ``channel``). If specified, cellpose runs in dual channel mode.  For dual channel segmentation of cells, the first channel should contain the membrane marker, the second channel should contain the nuclear marker."
+            "description": "Second channel for segmentation (in the same format as ``channel``). If specified, cellpose runs in dual channel mode. For dual channel segmentation of cells, the first channel should contain the membrane marker, the second channel should contain the nuclear marker."
           },
           "input_ROI_table": {
             "title": "Input Roi Table",
@@ -536,7 +536,7 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "Dictionary where keys match the ``wavelength_id`` attributes of existing channels (e.g.  ``A01_C01`` ) and values are the filenames of the corresponding illumination profiles."
+            "description": "Dictionary where keys match the ``wavelength_id`` attributes of existing channels (e.g. ``A01_C01`` ) and values are the filenames of the corresponding illumination profiles."
           },
           "background": {
             "title": "Background",
@@ -837,7 +837,7 @@
               "max": {
                 "title": "Max",
                 "type": "integer",
-                "description": "Do not change. It will be set according to bit-depth of the images by     default (e.g. 65535 for 16 bit images)."
+                "description": "Do not change. It will be set according to bit-depth of the images by default (e.g. 65535 for 16 bit images)."
               },
               "start": {
                 "title": "Start",
@@ -877,12 +877,12 @@
               },
               "window": {
                 "$ref": "#/definitions/Window",
-                "description": "Optional ``Window`` object to set default display settings for     napari."
+                "description": "Optional ``Window`` object to set default display settings for napari."
               },
               "color": {
                 "title": "Color",
                 "type": "string",
-                "description": "Optional hex colormap to display the channel in napari     (e.g. ``00FFFF``)."
+                "description": "Optional hex colormap to display the channel in napari (e.g. ``00FFFF``)."
               },
               "active": {
                 "title": "Active",

--- a/fractal_tasks_core/__FRACTAL_MANIFEST__.json
+++ b/fractal_tasks_core/__FRACTAL_MANIFEST__.json
@@ -83,22 +83,22 @@
               "min": {
                 "title": "Min",
                 "type": "integer",
-                "description": "If not provided, it will be set to ``0``."
+                "description": "Do not change. It will be set to ``0`` by default."
               },
               "max": {
                 "title": "Max",
                 "type": "integer",
-                "description": "If not provided, it will be set according to bit-depth."
+                "description": "Do not change. It will be set according to bit-depth of the images by\n    default (e.g. 65535 for 16 bit images)."
               },
               "start": {
                 "title": "Start",
                 "type": "integer",
-                "description": "Start value of the visualization window."
+                "description": "Lower-bound rescaling value for visualization."
               },
               "end": {
                 "title": "End",
                 "type": "integer",
-                "description": "End value of the visualization window."
+                "description": "Upper-bound rescaling value for visualization."
               }
             },
             "required": [
@@ -114,44 +114,44 @@
               "wavelength_id": {
                 "title": "Wavelength Id",
                 "type": "string",
-                "description": "Custom attribute (e.g. ``A01_C01``)."
+                "description": "Unique ID for the channel wavelength, e.g. ``A01_C01``."
               },
               "index": {
                 "title": "Index",
                 "type": "integer",
-                "description": "For internal use only."
+                "description": "Do not change. For internal use only. "
               },
               "label": {
                 "title": "Label",
                 "type": "string",
-                "description": "Channel label."
+                "description": "Name of the channel"
               },
               "window": {
                 "$ref": "#/definitions/Window",
-                "description": "Optional ``Window`` object to display this channel in napari."
+                "description": "Optional ``Window`` object to set default display settings for\n    napari."
               },
               "color": {
                 "title": "Color",
                 "type": "string",
-                "description": "Optional colormap to display the channel in napari (e.g. ``00FFFF``)."
+                "description": "Optional hex colormap to display the channel in napari\n    (e.g. ``00FFFF``)."
               },
               "active": {
                 "title": "Active",
                 "default": true,
                 "type": "boolean",
-                "description": "Omero-channel attribute."
+                "description": "Should this channel be shown in the viewer?"
               },
               "coefficient": {
                 "title": "Coefficient",
                 "default": 1,
                 "type": "integer",
-                "description": "Omero-channel attribute."
+                "description": "Do not change. Omero-channel attribute. "
               },
               "inverted": {
                 "title": "Inverted",
                 "default": false,
                 "type": "boolean",
-                "description": "Omero-channel attribute."
+                "description": "Do not change. Omero-channel attribute."
               }
             },
             "required": [
@@ -480,7 +480,7 @@
               "label": {
                 "title": "Label",
                 "type": "string",
-                "description": "Channel label."
+                "description": "Name of the channel"
               }
             }
           }
@@ -674,7 +674,7 @@
               "label": {
                 "title": "Label",
                 "type": "string",
-                "description": "Channel label."
+                "description": "Name of the channel"
               }
             }
           },
@@ -832,22 +832,22 @@
               "min": {
                 "title": "Min",
                 "type": "integer",
-                "description": "If not provided, it will be set to ``0``."
+                "description": "Do not change. It will be set to ``0`` by default."
               },
               "max": {
                 "title": "Max",
                 "type": "integer",
-                "description": "If not provided, it will be set according to bit-depth."
+                "description": "Do not change. It will be set according to bit-depth of the images by\n    default (e.g. 65535 for 16 bit images)."
               },
               "start": {
                 "title": "Start",
                 "type": "integer",
-                "description": "Start value of the visualization window."
+                "description": "Lower-bound rescaling value for visualization."
               },
               "end": {
                 "title": "End",
                 "type": "integer",
-                "description": "End value of the visualization window."
+                "description": "Upper-bound rescaling value for visualization."
               }
             },
             "required": [
@@ -863,44 +863,44 @@
               "wavelength_id": {
                 "title": "Wavelength Id",
                 "type": "string",
-                "description": "Custom attribute (e.g. ``A01_C01``)."
+                "description": "Unique ID for the channel wavelength, e.g. ``A01_C01``."
               },
               "index": {
                 "title": "Index",
                 "type": "integer",
-                "description": "For internal use only."
+                "description": "Do not change. For internal use only. "
               },
               "label": {
                 "title": "Label",
                 "type": "string",
-                "description": "Channel label."
+                "description": "Name of the channel"
               },
               "window": {
                 "$ref": "#/definitions/Window",
-                "description": "Optional ``Window`` object to display this channel in napari."
+                "description": "Optional ``Window`` object to set default display settings for\n    napari."
               },
               "color": {
                 "title": "Color",
                 "type": "string",
-                "description": "Optional colormap to display the channel in napari (e.g. ``00FFFF``)."
+                "description": "Optional hex colormap to display the channel in napari\n    (e.g. ``00FFFF``)."
               },
               "active": {
                 "title": "Active",
                 "default": true,
                 "type": "boolean",
-                "description": "Omero-channel attribute."
+                "description": "Should this channel be shown in the viewer?"
               },
               "coefficient": {
                 "title": "Coefficient",
                 "default": 1,
                 "type": "integer",
-                "description": "Omero-channel attribute."
+                "description": "Do not change. Omero-channel attribute. "
               },
               "inverted": {
                 "title": "Inverted",
                 "default": false,
                 "type": "boolean",
-                "description": "Omero-channel attribute."
+                "description": "Do not change. Omero-channel attribute."
               }
             },
             "required": [

--- a/fractal_tasks_core/dev/lib_descriptions.py
+++ b/fractal_tasks_core/dev/lib_descriptions.py
@@ -5,6 +5,23 @@ from pathlib import Path
 from docstring_parser import parse as docparse
 
 
+def _sanitize_description(string: str) -> str:
+    """
+    Sanitize a description string.
+
+    This is a provisional helper function that replaces newlines with spaces
+    and reduces multiple contiguous whitespace characters to a single one.
+    Future iterations of the docstrings format/parsing may render this function
+    not-needed or obsolete.
+    """
+    # Replace newline with space
+    new_string = string.replace("\n", " ")
+    # Replace N-whitespace characterss with a single one
+    while "  " in new_string:
+        new_string = new_string.replace("  ", " ")
+    return new_string
+
+
 def _get_function_args_descriptions(
     package_name: str, module_relative_path: str, function_name: str
 ) -> dict[str, str]:
@@ -35,7 +52,7 @@ def _get_function_args_descriptions(
     # Parse docstring (via docstring_parser) and prepare output
     parsed_docstring = docparse(docstring)
     descriptions = {
-        param.arg_name: param.description.replace("\n", " ")
+        param.arg_name: _sanitize_description(param.description)
         for param in parsed_docstring.params
     }
     return descriptions
@@ -74,9 +91,7 @@ def _get_class_attrs_descriptions(
             var_name = node.target.id
         else:
             if isinstance(node, ast.Expr) and var_name:
-                description = node.value.s
-                description = description.replace("\n", " ")
-                descriptions[var_name] = description
+                descriptions[var_name] = _sanitize_description(node.value.s)
                 var_name = ""
     return descriptions
 

--- a/fractal_tasks_core/dev/lib_descriptions.py
+++ b/fractal_tasks_core/dev/lib_descriptions.py
@@ -74,7 +74,9 @@ def _get_class_attrs_descriptions(
             var_name = node.target.id
         else:
             if isinstance(node, ast.Expr) and var_name:
-                descriptions[var_name] = node.value.s
+                description = node.value.s
+                description = description.replace("\n", " ")
+                descriptions[var_name] = description
                 var_name = ""
     return descriptions
 

--- a/fractal_tasks_core/lib_channels.py
+++ b/fractal_tasks_core/lib_channels.py
@@ -38,16 +38,17 @@ class Window(BaseModel):
     """
 
     min: Optional[int]
-    """If not provided, it will be set to ``0``."""
+    """Do not change. It will be set to ``0`` by default."""
 
     max: Optional[int]
-    """If not provided, it will be set according to bit-depth."""
+    """Do not change. It will be set according to bit-depth of the images by
+    default (e.g. 65535 for 16 bit images)."""
 
     start: int
-    """Start value of the visualization window."""
+    """Lower-bound rescaling value for visualization."""
 
     end: int
-    """End value of the visualization window."""
+    """Upper-bound rescaling value for visualization."""
 
 
 class OmeroChannel(BaseModel):
@@ -58,30 +59,32 @@ class OmeroChannel(BaseModel):
     # Custom
 
     wavelength_id: str
-    """Custom attribute (e.g. ``A01_C01``)."""
+    """Unique ID for the channel wavelength, e.g. ``A01_C01``."""
 
     index: Optional[int]
-    """For internal use only."""
+    """Do not change. For internal use only. """
 
     # From OME-NGFF v0.4 transitional metadata
 
     label: Optional[str]
-    """Channel label."""
+    """Name of the channel"""
 
     window: Optional[Window]
-    """Optional ``Window`` object to display this channel in napari."""
+    """Optional ``Window`` object to set default display settings for
+    napari."""
 
     color: Optional[str]
-    """Optional colormap to display the channel in napari (e.g. ``00FFFF``)."""
+    """Optional hex colormap to display the channel in napari
+    (e.g. ``00FFFF``)."""
 
     active: bool = True
-    """Omero-channel attribute."""
+    """Should this channel be shown in the viewer?"""
 
     coefficient: int = 1
-    """Omero-channel attribute."""
+    """Do not change. Omero-channel attribute. """
 
     inverted: bool = False
-    """Omero-channel attribute."""
+    """Do not change. Omero-channel attribute."""
 
 
 class ChannelNotFoundError(ValueError):

--- a/fractal_tasks_core/lib_channels.py
+++ b/fractal_tasks_core/lib_channels.py
@@ -62,7 +62,7 @@ class OmeroChannel(BaseModel):
     """Unique ID for the channel wavelength, e.g. ``A01_C01``."""
 
     index: Optional[int]
-    """Do not change. For internal use only. """
+    """Do not change. For internal use only."""
 
     # From OME-NGFF v0.4 transitional metadata
 

--- a/fractal_tasks_core/lib_input_models.py
+++ b/fractal_tasks_core/lib_input_models.py
@@ -29,7 +29,7 @@ class Channel(BaseModel):
     """Unique ID for the channel wavelength, e.g. ``A01_C01``."""
 
     label: Optional[str] = None
-    """Channel label."""
+    """Name of the channel"""
 
     @validator("label", always=True)
     def mutually_exclusive_channel_attributes(cls, v, values):


### PR DESCRIPTION
Here's a few minor suggested changes to the docstrings (see https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/421).

@tcompa 2 docstrings are now just barely 2 lines long, hope that's ok. Not sure about the formatting of this (should it be switched to """ on a separate line for those?). Feel free to change that. Other than that, looks good!