### PR TITLE
Set ROI origin to match well origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ This release includes work on ROI tables.
 
 * Set `FOV_ROI_table` and `well_ROI_table` ZYX origin to zero (\#524):
     * Remove heuristics to determine whether to reset origin, in `cellpose_segmentation` task;
-    * Remove `reset_origin` argument from `convert_ROI_table_to_indices` function.
+    * Remove obsolete `reset_origin` argument from `convert_ROI_table_to_indices` function.
+    * Remove redundant `reset_origin` call from `apply_registration_to_ROI_tables` task.
 * Fix bug in creation of bounding-box ROIs when `cellpose_segmentation` loops of FOVs (\#524).
-* Update `metadata` parameter of `prepare_FOV_ROI_table` and `prepare_well_ROI_table` functions (\#524).
+* Update type of `metadata` parameter of `prepare_FOV_ROI_table` and `prepare_well_ROI_table` functions (\#524).
 * Fix `reset_origin` so that it returns an updated copy of its input (\#524).
 
 # 0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This release includes work on ROI tables.
     * Remove `reset_origin` argument from `convert_ROI_table_to_indices` function.
 * Fix bug in creation of bounding-box ROIs when `cellpose_segmentation` loops of FOVs (\#524).
 * Update `metadata` parameter of `prepare_FOV_ROI_table` and `prepare_well_ROI_table` functions (\#524).
+* Fix `reset_origin` so that it returns an updated copy of its input (\#524).
 
 # 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-tasks-core repository.
 
+# Unreleased
+
+This release includes work on ROI tables.
+
+* Set `FOV_ROI_table` and `well_ROI_table` ZYX origin to zero (\#524):
+    * Remove heuristics to determine whether to reset origin, in `cellpose_segmentation` task;
+    * Remove `reset_origin` argument from `convert_ROI_table_to_indices` function.
+* Fix bug in creation of bounding-box ROIs when `cellpose_segmentation` loops of FOVs (\#524).
+* Update `metadata` parameter of `prepare_FOV_ROI_table` and `prepare_well_ROI_table` functions (\#524).
+
 # 0.11.0
 
 * Tasks:

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -30,6 +30,13 @@ logger = logging.getLogger(__name__)
 def _reset_origin_in_dataframe(
     df: pd.DataFrame, columns: list[str]
 ) -> pd.DataFrame:
+    """
+    Reset origin for columns `columns` of dataframe `df`, and return a copy.
+
+    Args:
+        df: Original DataFrame.
+        columns: Columns to be shifted.
+    """
     new_df = df.copy()
     for column in columns:
         new_df[column] -= new_df[column].min()

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -224,7 +224,7 @@ def convert_ROI_table_to_indices(
     ],
 ) -> list[list[int]]:
     """
-    Convert an ROIs in an AnnData table into integer array indices.
+    Convert the an ROI AnnData table into integer array indices.
 
     Args:
         ROI: AnnData table with list of ROIs.

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -224,7 +224,7 @@ def convert_ROI_table_to_indices(
     ],
 ) -> list[list[int]]:
     """
-    Convert the an ROI AnnData table into integer array indices.
+    Convert a ROI AnnData table into integer array indices.
 
     Args:
         ROI: AnnData table with list of ROIs.

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -301,7 +301,9 @@ def array_to_bounding_box_table(
         corresponds to a unique value of `mask_array`. ROI properties are
         expressed in physical units (with columns defined as elsewhere this
         module - see e.g. `prepare_well_ROI_table`), and positions are
-        optionally shifted (if `origin_zyx` is set).
+        optionally shifted (if `origin_zyx` is set). An additional column
+        `label` keeps track of the `mask_array` value corresponding to each
+        ROI.
     """
 
     pxl_sizes_zyx_array = np.array(pxl_sizes_zyx)

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -233,10 +233,11 @@ def convert_ROI_table_to_indices(
         "len_y_micrometer",
         "len_z_micrometer",
     ],
-    reset_origin: bool = True,  # FIXME remove this? or make it always true?
 ) -> list[list[int]]:
     """
     TBD
+
+    FIXME: add docstring
 
     Args:
         ROI: TBD
@@ -245,7 +246,6 @@ def convert_ROI_table_to_indices(
         coarsening_xy: TBD
         cols_xyz_pos: TBD
         cols_xyz_len: TBD
-        reset_origin: TBD
     """
     # Handle empty ROI table
     if len(ROI) == 0:
@@ -260,24 +260,13 @@ def convert_ROI_table_to_indices(
     x_pos, y_pos, z_pos = cols_xyz_pos[:]
     x_len, y_len, z_len = cols_xyz_len[:]
 
-    # FIXME: see discussion on ROI-table origin at
-    # https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/339
-    if reset_origin:
-        origin_x = min(ROI[:, x_pos].X[:, 0])
-        origin_y = min(ROI[:, y_pos].X[:, 0])
-        origin_z = min(ROI[:, z_pos].X[:, 0])
-    else:
-        origin_x = 0.0
-        origin_y = 0.0
-        origin_z = 0.0
-
     list_indices = []
     for FOV in ROI.obs_names:
 
         # Extract data from anndata table
-        x_micrometer = ROI[FOV, x_pos].X[0, 0] - origin_x
-        y_micrometer = ROI[FOV, y_pos].X[0, 0] - origin_y
-        z_micrometer = ROI[FOV, z_pos].X[0, 0] - origin_z
+        x_micrometer = ROI[FOV, x_pos].X[0, 0]
+        y_micrometer = ROI[FOV, y_pos].X[0, 0]
+        z_micrometer = ROI[FOV, z_pos].X[0, 0]
         len_x_micrometer = ROI[FOV, x_len].X[0, 0]
         len_y_micrometer = ROI[FOV, y_len].X[0, 0]
         len_z_micrometer = ROI[FOV, z_len].X[0, 0]

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -282,14 +282,13 @@ def array_to_bounding_box_table(
     pxl_sizes_zyx: list[float],
     origin_zyx: tuple[int, int, int] = (0, 0, 0),
 ) -> pd.DataFrame:
-
     """
-    TBD
+    Construct bounding-box ROI table for a mask array.
 
     Args:
-        mask_array: TBD
-        pxl_sizes_zyx: TBD
-        origin_zyx: If set, shift origin by this amount of pixels.
+        mask_array: Original array to construct bounding boxes.
+        pxl_sizes_zyx: Physical-unit pixel ZYX sizes.
+        origin_zyx: Shift ROI origin by this amount of ZYX pixels.
     """
 
     pxl_sizes_zyx_array = np.array(pxl_sizes_zyx)

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -234,6 +234,12 @@ def convert_ROI_table_to_indices(
         coarsening_xy: Linear coarsening factor in the YX plane.
         cols_xyz_pos: Column names for XYZ ROI positions.
         cols_xyz_len: Column names for XYZ ROI edges.
+
+    Returns:
+        Nested list of indices. The main list has one item per ROI. Each ROI
+        item is a list of six integers as in `[start_z, end_z, start_y, end_y,
+        start_x, end_x]`. The array-index interval for a given ROI is
+        `start_x:end_x` along X, and so on for Y and Z.
     """
     # Handle empty ROI table
     if len(ROI) == 0:
@@ -289,6 +295,13 @@ def array_to_bounding_box_table(
         mask_array: Original array to construct bounding boxes.
         pxl_sizes_zyx: Physical-unit pixel ZYX sizes.
         origin_zyx: Shift ROI origin by this amount of ZYX pixels.
+
+    Returns:
+        DataFrame with each line representing the bounding-box ROI that
+        corresponds to a unique value of `mask_array`. ROI properties are
+        expressed in physical units (with columns defined as elsewhere this
+        module - see e.g. `prepare_well_ROI_table`), and positions are
+        optionally shifted (if `origin_zyx` is set).
     """
 
     pxl_sizes_zyx_array = np.array(pxl_sizes_zyx)
@@ -481,6 +494,10 @@ def reset_origin(
         x_pos: Name of the column with X position of ROIs.
         y_pos: Name of the column with Y position of ROIs.
         z_pos: Name of the column with Z position of ROIs.
+
+    Returns:
+        A copy of the `ROI_table` AnnData table, where values of `x_pos`,
+        `y_pos` and `z_pos` columns have been shifted by their minimum values.
     """
     new_table = ROI_table.copy()
 

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -42,6 +42,8 @@ def prepare_FOV_ROI_table(
     """
     TBD
 
+    FIXME add docstring
+
     Args:
         df: TBD
         metadata: TBD
@@ -80,6 +82,12 @@ def prepare_FOV_ROI_table(
     # when creating AnnData object
     df_roi = df.loc[:, positional_columns].astype(np.float32)
 
+    # Reset origin of the FOV ROI table, so that it matches with the well
+    # origin
+    df_roi = _reset_origin_in_dataframe(
+        df_roi, columns=["x_micrometer", "y_micrometer", "z_micrometer"]
+    )
+
     # Create an AnnData object directly from the DataFrame
     adata = ad.AnnData(X=df_roi)
 
@@ -105,6 +113,8 @@ def prepare_well_ROI_table(
 ) -> ad.AnnData:
     """
     TBD
+
+    FIXME add docstring
 
     Args:
         df: TBD
@@ -150,6 +160,11 @@ def prepare_well_ROI_table(
     # >> UserWarning: X converted to numpy array with dtype float64
     # when creating AnnData object
     df_roi = df.iloc[0:1, :].loc[:, positional_columns].astype(np.float32)
+
+    # Reset origin of the single-entry well ROI table
+    df_roi = _reset_origin_in_dataframe(
+        df_roi, columns=["x_micrometer", "y_micrometer", "z_micrometer"]
+    )
 
     # Create an AnnData object directly from the DataFrame
     adata = ad.AnnData(X=df_roi)
@@ -218,7 +233,7 @@ def convert_ROI_table_to_indices(
         "len_y_micrometer",
         "len_z_micrometer",
     ],
-    reset_origin: bool = True,
+    reset_origin: bool = True,  # FIXME remove this? or make it always true?
 ) -> list[list[int]]:
     """
     TBD

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -237,9 +237,9 @@ def convert_ROI_table_to_indices(
 
     Returns:
         Nested list of indices. The main list has one item per ROI. Each ROI
-        item is a list of six integers as in `[start_z, end_z, start_y, end_y,
-        start_x, end_x]`. The array-index interval for a given ROI is
-        `start_x:end_x` along X, and so on for Y and Z.
+            item is a list of six integers as in `[start_z, end_z, start_y,
+            end_y, start_x, end_x]`. The array-index interval for a given ROI
+            is `start_x:end_x` along X, and so on for Y and Z.
     """
     # Handle empty ROI table
     if len(ROI) == 0:
@@ -298,12 +298,12 @@ def array_to_bounding_box_table(
 
     Returns:
         DataFrame with each line representing the bounding-box ROI that
-        corresponds to a unique value of `mask_array`. ROI properties are
-        expressed in physical units (with columns defined as elsewhere this
-        module - see e.g. `prepare_well_ROI_table`), and positions are
-        optionally shifted (if `origin_zyx` is set). An additional column
-        `label` keeps track of the `mask_array` value corresponding to each
-        ROI.
+            corresponds to a unique value of `mask_array`. ROI properties are
+            expressed in physical units (with columns defined as elsewhere this
+            module - see e.g. `prepare_well_ROI_table`), and positions are
+            optionally shifted (if `origin_zyx` is set). An additional column
+            `label` keeps track of the `mask_array` value corresponding to each
+            ROI.
     """
 
     pxl_sizes_zyx_array = np.array(pxl_sizes_zyx)
@@ -499,7 +499,8 @@ def reset_origin(
 
     Returns:
         A copy of the `ROI_table` AnnData table, where values of `x_pos`,
-        `y_pos` and `z_pos` columns have been shifted by their minimum values.
+            `y_pos` and `z_pos` columns have been shifted by their minimum
+            values.
     """
     new_table = ROI_table.copy()
 

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -470,20 +470,21 @@ def reset_origin(
     y_pos: str = "y_micrometer",
     z_pos: str = "z_micrometer",
 ):
-
     """
-    FIXME: is this in-place??
+    Return a copy of a ROI table, with shifted-to-zero origin for some columns.
     """
+    new_table = ROI_table.copy()
 
-    origin_x = min(ROI_table[:, x_pos].X[:, 0])
-    origin_y = min(ROI_table[:, y_pos].X[:, 0])
-    origin_z = min(ROI_table[:, z_pos].X[:, 0])
-    for FOV in ROI_table.obs_names:
-        ROI_table[FOV, x_pos] = ROI_table[FOV, x_pos].X[0, 0] - origin_x
-        ROI_table[FOV, y_pos] = ROI_table[FOV, y_pos].X[0, 0] - origin_y
-        ROI_table[FOV, z_pos] = ROI_table[FOV, z_pos].X[0, 0] - origin_z
+    origin_x = min(new_table[:, x_pos].X[:, 0])
+    origin_y = min(new_table[:, y_pos].X[:, 0])
+    origin_z = min(new_table[:, z_pos].X[:, 0])
 
-    return ROI_table
+    for FOV in new_table.obs_names:
+        new_table[FOV, x_pos] = new_table[FOV, x_pos].X[0, 0] - origin_x
+        new_table[FOV, y_pos] = new_table[FOV, y_pos].X[0, 0] - origin_y
+        new_table[FOV, z_pos] = new_table[FOV, z_pos].X[0, 0] - origin_z
+
+    return new_table
 
 
 def is_standard_roi_table(table: str) -> bool:

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -466,10 +466,14 @@ def convert_indices_to_regions(
 
 def reset_origin(
     ROI_table: ad.AnnData,
-    x_pos="x_micrometer",
-    y_pos="y_micrometer",
-    z_pos="z_micrometer",
+    x_pos: str = "x_micrometer",
+    y_pos: str = "y_micrometer",
+    z_pos: str = "z_micrometer",
 ):
+
+    """
+    FIXME: is this in-place??
+    """
 
     origin_x = min(ROI_table[:, x_pos].X[:, 0])
     origin_y = min(ROI_table[:, y_pos].X[:, 0])

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -27,6 +27,15 @@ import zarr
 logger = logging.getLogger(__name__)
 
 
+def _reset_origin_in_dataframe(
+    df: pd.DataFrame, columns: list[str]
+) -> pd.DataFrame:
+    new_df = df.copy()
+    for column in columns:
+        new_df[column] -= new_df[column].min()
+    return new_df
+
+
 def prepare_FOV_ROI_table(
     df: pd.DataFrame, metadata: list[str] = ["time"]
 ) -> ad.AnnData:

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -476,6 +476,12 @@ def reset_origin(
 ):
     """
     Return a copy of a ROI table, with shifted-to-zero origin for some columns.
+
+    Args:
+        ROI_table: Original ROI table.
+        x_pos: Name of the column with X position of ROIs.
+        y_pos: Name of the column with Y position of ROIs.
+        z_pos: Name of the column with Z position of ROIs.
     """
     new_table = ROI_table.copy()
 

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -37,16 +37,17 @@ def _reset_origin_in_dataframe(
 
 
 def prepare_FOV_ROI_table(
-    df: pd.DataFrame, metadata: list[str] = ["time"]
+    df: pd.DataFrame, metadata: tuple[str, ...] = ("time",)
 ) -> ad.AnnData:
     """
-    TBD
-
-    FIXME add docstring
+    Prepare an AnnData table for fields-of-view ROIs.
 
     Args:
-        df: TBD
-        metadata: TBD
+        df:
+            Input dataframe, possibly prepared through
+            `parse_yokogawa_metadata`.
+        metadata:
+            Columns of `df` to be stored (if present) into AnnData table `obs`.
     """
 
     # Make a local copy of the dataframe, to avoid SettingWithCopyWarning
@@ -109,16 +110,17 @@ def prepare_FOV_ROI_table(
 
 
 def prepare_well_ROI_table(
-    df: pd.DataFrame, metadata: list[str] = ["time"]
+    df: pd.DataFrame, metadata: tuple[str, ...] = ("time",)
 ) -> ad.AnnData:
     """
-    TBD
-
-    FIXME add docstring
+    Prepare an AnnData table with a single well ROI.
 
     Args:
-        df: TBD
-        metadata: TBD
+        df:
+            Input dataframe, possibly prepared through
+            `parse_yokogawa_metadata`.
+        metadata:
+            Columns of `df` to be stored (if present) into AnnData table `obs`.
     """
 
     # Make a local copy of the dataframe, to avoid SettingWithCopyWarning
@@ -235,17 +237,16 @@ def convert_ROI_table_to_indices(
     ],
 ) -> list[list[int]]:
     """
-    TBD
-
-    FIXME: add docstring
+    Convert an ROIs in an AnnData table into integer array indices.
 
     Args:
-        ROI: TBD
-        full_res_pxl_sizes_zyx: TBD
-        level: TBD
-        coarsening_xy: TBD
-        cols_xyz_pos: TBD
-        cols_xyz_len: TBD
+        ROI: AnnData table with list of ROIs.
+        full_res_pxl_sizes_zyx:
+            Physical-unit pixel ZYX sizes at the full-resolution pyramid level.
+        level: Pyramid level.
+        coarsening_xy: Linear coarsening factor in the YX plane.
+        cols_xyz_pos: Column names for XYZ ROI positions.
+        cols_xyz_len: Column names for XYZ ROI edges.
     """
     # Handle empty ROI table
     if len(ROI) == 0:

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -27,22 +27,6 @@ import zarr
 logger = logging.getLogger(__name__)
 
 
-def _reset_origin_in_dataframe(
-    df: pd.DataFrame, columns: list[str]
-) -> pd.DataFrame:
-    """
-    Reset origin for columns `columns` of dataframe `df`, and return a copy.
-
-    Args:
-        df: Original DataFrame.
-        columns: Columns to be shifted.
-    """
-    new_df = df.copy()
-    for column in columns:
-        new_df[column] -= new_df[column].min()
-    return new_df
-
-
 def prepare_FOV_ROI_table(
     df: pd.DataFrame, metadata: tuple[str, ...] = ("time",)
 ) -> ad.AnnData:
@@ -90,14 +74,12 @@ def prepare_FOV_ROI_table(
     # when creating AnnData object
     df_roi = df.loc[:, positional_columns].astype(np.float32)
 
-    # Reset origin of the FOV ROI table, so that it matches with the well
-    # origin
-    df_roi = _reset_origin_in_dataframe(
-        df_roi, columns=["x_micrometer", "y_micrometer", "z_micrometer"]
-    )
-
     # Create an AnnData object directly from the DataFrame
     adata = ad.AnnData(X=df_roi)
+
+    # Reset origin of the FOV ROI table, so that it matches with the well
+    # origin
+    adata = reset_origin(adata)
 
     # Save any metadata that is specified to the obs df
     for col in metadata:
@@ -170,13 +152,11 @@ def prepare_well_ROI_table(
     # when creating AnnData object
     df_roi = df.iloc[0:1, :].loc[:, positional_columns].astype(np.float32)
 
-    # Reset origin of the single-entry well ROI table
-    df_roi = _reset_origin_in_dataframe(
-        df_roi, columns=["x_micrometer", "y_micrometer", "z_micrometer"]
-    )
-
     # Create an AnnData object directly from the DataFrame
     adata = ad.AnnData(X=df_roi)
+
+    # Reset origin of the single-entry well ROI table
+    adata = reset_origin(adata)
 
     # Save any metadata that is specified to the obs df
     for col in metadata:

--- a/fractal_tasks_core/lib_regions_of_interest.py
+++ b/fractal_tasks_core/lib_regions_of_interest.py
@@ -485,7 +485,7 @@ def reset_origin(
     x_pos: str = "x_micrometer",
     y_pos: str = "y_micrometer",
     z_pos: str = "z_micrometer",
-):
+) -> ad.AnnData:
     """
     Return a copy of a ROI table, with shifted-to-zero origin for some columns.
 

--- a/fractal_tasks_core/tasks/apply_registration_to_ROI_tables.py
+++ b/fractal_tasks_core/tasks/apply_registration_to_ROI_tables.py
@@ -29,7 +29,6 @@ from pydantic.decorator import validate_arguments
 from fractal_tasks_core.lib_regions_of_interest import (
     are_ROI_table_columns_valid,
 )
-from fractal_tasks_core.lib_regions_of_interest import reset_origin
 from fractal_tasks_core.lib_zattrs_utils import get_acquisition_paths
 
 logger = logging.getLogger(__name__)
@@ -126,15 +125,6 @@ def apply_registration_to_ROI_tables(
                 "this task."
             )
         roi_tables[acq] = curr_ROI_table
-
-    # Reset all the origins
-    # Related to
-    # https://github.com/fractal-analytics-platform/fractal-tasks-core/pull/487
-    # May not be necessary long-term if we move to 0, 0, 0 origins or specific
-    # coordinate systems with defined origins
-    logger.info(f"Reset ROI origins for new {new_roi_table} table")
-    for acq, acq_roi_table in roi_tables.items():
-        roi_tables[acq] = reset_origin(acq_roi_table)
 
     # Check that all acquisitions have the same ROIs
     rois = roi_tables[reference_cycle].obs.index

--- a/fractal_tasks_core/tasks/apply_registration_to_image.py
+++ b/fractal_tasks_core/tasks/apply_registration_to_image.py
@@ -296,14 +296,12 @@ def write_registered_zarr(
         level=0,
         coarsening_xy=coarsening_xy,
         full_res_pxl_sizes_zyx=pxl_sizes_zyx,
-        reset_origin=False,
     )
     list_indices_ref = convert_ROI_table_to_indices(
         ROI_table_ref,
         level=0,
         coarsening_xy=coarsening_xy,
         full_res_pxl_sizes_zyx=pxl_sizes_zyx,
-        reset_origin=False,
     )
 
     old_image_group = zarr.open_group(f"{input_path / component}", mode="r")

--- a/fractal_tasks_core/tasks/cellpose_segmentation.py
+++ b/fractal_tasks_core/tasks/cellpose_segmentation.py
@@ -348,20 +348,12 @@ def cellpose_segmentation(
     )
     logger.info(f"{actual_res_pxl_sizes_zyx=}")
 
-    # Heuristic to determine reset_origin   # FIXME, see issue #339
-    if input_ROI_table in ["FOV_ROI_table", "well_ROI_table"]:
-        reset_origin = True
-    else:
-        reset_origin = False
-    logger.info(f"{reset_origin=}")
-
     # Create list of indices for 3D ROIs spanning the entire Z direction
     list_indices = convert_ROI_table_to_indices(
         ROI_table,
         level=level,
         coarsening_xy=coarsening_xy,
         full_res_pxl_sizes_zyx=full_res_pxl_sizes_zyx,
-        reset_origin=reset_origin,
     )
 
     # If we are not planning to use masked loading, fail for overlapping ROIs

--- a/fractal_tasks_core/tasks/cellpose_segmentation.py
+++ b/fractal_tasks_core/tasks/cellpose_segmentation.py
@@ -600,7 +600,9 @@ def cellpose_segmentation(
 
         if output_ROI_table:
             bbox_df = array_to_bounding_box_table(
-                new_label_img, actual_res_pxl_sizes_zyx
+                new_label_img,
+                actual_res_pxl_sizes_zyx,
+                origin_zyx=(s_z, s_y, s_x),
             )
 
             bbox_dataframe_list.append(bbox_df)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,8 +101,8 @@ def zenodo_zarr(testdata_path, tmpdir_factory):
             shutil.move(str(rootfolder / zarrname), str(folder))
 
             # Update well/FOV ROI tables, by shifting their origin to 0
-            # (https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/339)
-            # FIXME: remove this fix, by uploading new zarrs to zenodo
+            # TODO: remove this fix, by uploading new zarrs to zenodo (ref
+            # issue 526)
             image_group_path = folder / "B/03/0"
             group_image = zarr.open_group(str(image_group_path))
             for table_name in ["FOV_ROI_table", "well_ROI_table"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,14 @@ def zenodo_zarr(testdata_path, tmpdir_factory):
     if rootfolder.exists():
         print(f"{str(rootfolder)} already exists, skip")
     else:
+
+        import zarr
+        import anndata as ad
+        import logging
+
+        from fractal_tasks_core.lib_regions_of_interest import reset_origin
+        from fractal_tasks_core.lib_write import write_table
+
         rootfolder.mkdir()
         tmp_path = tmpdir_factory.mktemp("zenodo_zarr")
         zarrnames = [
@@ -91,6 +99,23 @@ def zenodo_zarr(testdata_path, tmpdir_factory):
                 str(tmp_path / zipname), extract_dir=rootfolder, format="zip"
             )
             shutil.move(str(rootfolder / zarrname), str(folder))
+
+            # Update well/FOV ROI tables, by shifting their origin to 0
+            # (https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/339)
+            # FIXME: remove this fix, by uploading new zarrs to zenodo
+            image_group_path = folder / "B/03/0"
+            group_image = zarr.open_group(str(image_group_path))
+            for table_name in ["FOV_ROI_table", "well_ROI_table"]:
+                table_path = str(image_group_path / "tables" / table_name)
+                old_table = ad.read_zarr(table_path)
+                new_table = reset_origin(old_table)
+                write_table(
+                    group_image,
+                    table_name,
+                    new_table,
+                    overwrite=True,
+                    logger=logging.getLogger(),
+                )
 
     folders = [str(f) for f in folders]
 

--- a/tests/tasks/test_registration.py
+++ b/tests/tasks/test_registration.py
@@ -331,7 +331,6 @@ def test_multiplexing_registration(
             level=0,
             coarsening_xy=2,
             full_res_pxl_sizes_zyx=pxl_sizes_zyx,
-            reset_origin=True,
         )
         region = convert_indices_to_regions(list_indices[0])
         data_array = da.from_zarr(f"{zarr_path_mip / component / str(0)}")[0]
@@ -349,7 +348,6 @@ def test_multiplexing_registration(
             level=0,
             coarsening_xy=2,
             full_res_pxl_sizes_zyx=pxl_sizes_zyx,
-            reset_origin=False,  # no reset of origin!
         )
         region = convert_indices_to_regions(list_indices[0])
         data_array = da.from_zarr(f"{zarr_path_mip / component / str(0)}")[0]

--- a/tests/tasks/test_workflows_cellpose_segmentation.py
+++ b/tests/tasks/test_workflows_cellpose_segmentation.py
@@ -91,10 +91,12 @@ def patched_segment_ROI(
     nz, ny, nx = mask.shape
     if do_3D:
         mask[:, 0 : ny // 4, 0 : nx // 4] = 1  # noqa
-        mask[:, ny // 4 : ny // 2, 0:nx] = 2  # noqa
+        mask[:, ny // 4 : ny // 2, 0 : int(nx * 0.9)] = 2  # noqa
     else:
         mask[:, 0 : ny // 4, 0 : nx // 4] = 1  # noqa
-        mask[:, ny // 4 : ny // 2, 0:nx] = 2  # noqa
+        mask[:, 0 : ny // 2, 0 : nx // 4] = 1  # noqa
+        mask[:, 0 : ny // 4, 0 : nx // 2] = 1  # noqa
+        mask[:, int(ny * 3 / 4) : ny, int(nx * 3 / 4) : nx] = 2  # noqa
 
     logger.info(f"[{well_id}][patched_segment_ROI] END")
 
@@ -828,7 +830,7 @@ def test_workflow_secondary_labeling(
             channel=Channel(wavelength_id="A01_C01"),
             level=0,
             relabeling=True,
-            input_ROI_table="well_ROI_table",
+            input_ROI_table="FOV_ROI_table",
             output_label_name="organoids",
             output_ROI_table="organoid_ROI_table",
         )
@@ -840,11 +842,12 @@ def test_workflow_secondary_labeling(
     organoid_ROI_table_zarr_group = zarr.open(organoid_ROI_table_path)
     debug(organoid_ROI_table_zarr_group.attrs.asdict())
     debug(organoid_ROI_table)
-    NUM_LABELS = 2
-    assert organoid_ROI_table.obs.shape == (NUM_LABELS, 1)
-    assert organoid_ROI_table.shape == (NUM_LABELS, 6)
+    debug(organoid_ROI_table.X)
+    NUM_LABELS_PER_FOV = 2
+    assert organoid_ROI_table.obs.shape == (NUM_LABELS_PER_FOV * 2, 1)
+    assert organoid_ROI_table.shape == (NUM_LABELS_PER_FOV * 2, 6)
     assert len(organoid_ROI_table) > 0
-    assert np.max(organoid_ROI_table.X) == float(832)
+    assert np.max(organoid_ROI_table.X) == float(728)
 
     debug(zarr_path / metadata["image"][0])
 
@@ -862,5 +865,4 @@ def test_workflow_secondary_labeling(
             use_masks=True,
             output_label_name="nuclei",
         )
-
     # FIXME: what could we assert here?

--- a/tests/test_unit_ROIs.py
+++ b/tests/test_unit_ROIs.py
@@ -10,6 +10,9 @@ from anndata._io.specs import write_elem
 from devtools import debug
 
 from fractal_tasks_core.lib_regions_of_interest import (
+    _reset_origin_in_dataframe,
+)
+from fractal_tasks_core.lib_regions_of_interest import (
     are_ROI_table_columns_valid,
 )
 from fractal_tasks_core.lib_regions_of_interest import (
@@ -31,9 +34,7 @@ from fractal_tasks_core.lib_regions_of_interest import (
 from fractal_tasks_core.lib_regions_of_interest import load_region
 from fractal_tasks_core.lib_regions_of_interest import prepare_FOV_ROI_table
 from fractal_tasks_core.lib_regions_of_interest import prepare_well_ROI_table
-from fractal_tasks_core.lib_regions_of_interest import (
-    reset_origin,
-)
+from fractal_tasks_core.lib_regions_of_interest import reset_origin
 from fractal_tasks_core.lib_ROI_overlaps import find_overlaps_in_ROI_indices
 
 PIXEL_SIZE_X = 0.1625
@@ -454,3 +455,11 @@ def test_is_standard_roi_table():
     assert is_standard_roi_table("xxx_well_ROI_table_xxx")
     assert is_standard_roi_table("xxx_FOV_ROI_table_xxx")
     assert not is_standard_roi_table("something_else")
+
+
+def test_reset_origin_in_dataframe():
+    data = {"x": [3, 4, 5], "x_original": [3, 4, 5]}
+    df = pd.DataFrame(data)
+    new_df = _reset_origin_in_dataframe(df, columns=["x"])
+    assert (new_df["x"] == [0, 1, 2]).all()
+    assert (new_df["x_original"] == df["x_original"]).all()

--- a/tests/test_unit_ROIs.py
+++ b/tests/test_unit_ROIs.py
@@ -445,10 +445,16 @@ def test_reset_origin():
     debug(old_adata.X)
     # Reset origin
     new_adata = reset_origin(old_adata)
+    debug(old_adata.X)
     debug(new_adata.X)
+    # Check that new_adata was shifted
     assert abs(new_adata[:, "x_micrometer"].X[0, 0]) < 1e-10
     assert abs(new_adata[:, "y_micrometer"].X[0, 0]) < 1e-10
     assert abs(new_adata[:, "z_micrometer"].X[0, 0]) < 1e-10
+    # Check that old_adata was not modified
+    assert abs(old_adata[:, "x_micrometer"].X[0, 0] - 1.0) < 1e-10
+    assert abs(old_adata[:, "y_micrometer"].X[0, 0] - 1.0) < 1e-10
+    assert abs(old_adata[:, "z_micrometer"].X[0, 0] - 1.0) < 1e-10
 
 
 def test_is_standard_roi_table():

--- a/tests/test_unit_ROIs.py
+++ b/tests/test_unit_ROIs.py
@@ -10,9 +10,6 @@ from anndata._io.specs import write_elem
 from devtools import debug
 
 from fractal_tasks_core.lib_regions_of_interest import (
-    _reset_origin_in_dataframe,
-)
-from fractal_tasks_core.lib_regions_of_interest import (
     are_ROI_table_columns_valid,
 )
 from fractal_tasks_core.lib_regions_of_interest import (
@@ -497,11 +494,3 @@ def test_is_standard_roi_table():
     assert is_standard_roi_table("xxx_well_ROI_table_xxx")
     assert is_standard_roi_table("xxx_FOV_ROI_table_xxx")
     assert not is_standard_roi_table("something_else")
-
-
-def test_reset_origin_in_dataframe():
-    data = {"x": [3, 4, 5], "x_original": [3, 4, 5]}
-    df = pd.DataFrame(data)
-    new_df = _reset_origin_in_dataframe(df, columns=["x"])
-    assert (new_df["x"] == [0, 1, 2]).all()
-    assert (new_df["x_original"] == df["x_original"]).all()


### PR DESCRIPTION
- [x] Shift the FOV/well ROI tables so that their minimum XYZ values are at 0.
- [x] Remove workaround https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/339#issuecomment-1460020767
- [x] Adapt `zenodo_zarr` fixture to "fix" current zenodo datasets, and open issue about update (ref #526)
- [x] #460
- [x] #507
- [x] #525 
- [x] #527

Close #339
Close #460
Close #525
Close #507
Close #527


## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
