### PR TITLE
590 generalize calculate registration roi table handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 * Always use `write_table` in tasks, rather than AnnData `write_elem` (\#581).
+* Remove assumptions on columns in ROI frames from Calculate registration (image-based) (\#590).
 * Testing:
     * Cache Zenodo data, within GitHub actions (\#585).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-tasks-core repository.
 
-# Unreleased
+# 0.13.1
 
 * Always use `write_table` in tasks, rather than AnnData `write_elem` (\#581).
 * Remove assumptions on ROI-table columns from `get_ROI_table_with_translation` helper function of `calculate_registration_image_based` task (\#591).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Unreleased
 
 * Always use `write_table` in tasks, rather than AnnData `write_elem` (\#581).
-* Remove assumptions on columns in ROI frames from Calculate registration (image-based) (\#590).
+* Remove assumptions on ROI-table columns from `get_ROI_table_with_translation` helper function of `calculate_registration_image_based` task (\#591).
 * Testing:
     * Cache Zenodo data, within GitHub actions (\#585).
 

--- a/fractal_tasks_core/tasks/calculate_registration_image_based.py
+++ b/fractal_tasks_core/tasks/calculate_registration_image_based.py
@@ -327,24 +327,10 @@ def get_ROI_table_with_translation(
             f"different length ({len(new_roi_table)=}) "
             f"from the original ROI table ({len(ROI_table)=})"
         )
-    positional_columns = [
-        "x_micrometer",
-        "y_micrometer",
-        "z_micrometer",
-        "len_x_micrometer",
-        "len_y_micrometer",
-        "len_z_micrometer",
-        "x_micrometer_original",
-        "y_micrometer_original",
-        "translation_z",
-        "translation_y",
-        "translation_x",
-    ]
-    adata = ad.AnnData(
-        X=new_roi_table.loc[:, positional_columns].astype(np.float32)
-    )
+
+    adata = ad.AnnData(X=new_roi_table.astype(np.float32))
     adata.obs_names = new_roi_table.index
-    adata.var_names = list(map(str, positional_columns))
+    adata.var_names = list(map(str, new_roi_table.columns))
     return adata
 
 

--- a/tests/tasks/test_unit_registration_helper_functions.py
+++ b/tests/tasks/test_unit_registration_helper_functions.py
@@ -58,60 +58,105 @@ def test_calculate_physical_shifts(shifts):
     assert np.allclose(shifts_physical, expected_shifts_physical)
 
 
-@pytest.mark.parametrize("fail", [False, True])
-def test_get_ROI_table_with_translation(fail: bool):
-    new_shifts = {
-        "FOV_1": [
-            0,
-            7.8,
-            32.5,
-        ],
-        "FOV_2": [
-            0,
-            7.8,
-            32.5,
-        ],
-    }
-    if fail:
-        new_shifts.pop("FOV_2")
-    ROI_table = ad.AnnData(
-        X=np.array(
+ROI_table_FOV = ad.AnnData(
+    X=np.array(
+        [
             [
-                [
-                    -1.4483e03,
-                    -1.5177e03,
-                    0.0000e00,
-                    4.1600e02,
-                    3.5100e02,
-                    1.0000e00,
-                    -1.4483e03,
-                    -1.5177e03,
-                ],
-                [
-                    -1.0323e03,
-                    -1.5177e03,
-                    0.0000e00,
-                    4.1600e02,
-                    3.5100e02,
-                    1.0000e00,
-                    -1.0323e03,
-                    -1.5177e03,
-                ],
+                -1.4483e03,
+                -1.5177e03,
+                0.0000e00,
+                4.1600e02,
+                3.5100e02,
+                1.0000e00,
+                -1.4483e03,
+                -1.5177e03,
             ],
-            dtype=np.float32,
-        )
+            [
+                -1.0323e03,
+                -1.5177e03,
+                0.0000e00,
+                4.1600e02,
+                3.5100e02,
+                1.0000e00,
+                -1.0323e03,
+                -1.5177e03,
+            ],
+        ],
+        dtype=np.float32,
     )
-    ROI_table.obs_names = ["FOV_1", "FOV_2"]
-    ROI_table.var_names = [
-        "x_micrometer",
-        "y_micrometer",
-        "z_micrometer",
-        "len_x_micrometer",
-        "len_y_micrometer",
-        "len_z_micrometer",
-        "x_micrometer_original",
-        "y_micrometer_original",
-    ]
+)
+ROI_table_FOV.obs_names = ["FOV_1", "FOV_2"]
+ROI_table_FOV.var_names = [
+    "x_micrometer",
+    "y_micrometer",
+    "z_micrometer",
+    "len_x_micrometer",
+    "len_y_micrometer",
+    "len_z_micrometer",
+    "x_micrometer_original",
+    "y_micrometer_original",
+]
+new_shifts_FOV = {
+    "FOV_1": [
+        0,
+        7.8,
+        32.5,
+    ],
+    "FOV_2": [
+        0,
+        7.8,
+        32.5,
+    ],
+}
+
+
+ROI_table_well = ad.AnnData(
+    X=np.array(
+        [
+            [
+                -1.4483e03,
+                -1.5177e03,
+                0.0000e00,
+                4.1600e02,
+                3.5100e02,
+                1.0000e00,
+            ],
+        ],
+        dtype=np.float32,
+    )
+)
+ROI_table_well.obs_names = ["well_1"]
+ROI_table_well.var_names = [
+    "x_micrometer",
+    "y_micrometer",
+    "z_micrometer",
+    "len_x_micrometer",
+    "len_y_micrometer",
+    "len_z_micrometer",
+]
+new_shifts_well = {
+    "well_1": [
+        0,
+        7.8,
+        32.5,
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    "fail,ROI_table,new_shifts",
+    [
+        (False, ROI_table_FOV, new_shifts_FOV),
+        (True, ROI_table_FOV, new_shifts_FOV),
+        (False, ROI_table_well, new_shifts_well),
+    ],
+)
+def test_get_ROI_table_with_translation(
+    fail: bool, ROI_table: ad.AnnData, new_shifts: dict
+):
+    if fail:
+        new_shifts.pop(list(new_shifts.keys())[0])
+
     if fail:
         with pytest.raises(ValueError) as e:
             get_ROI_table_with_translation(ROI_table, new_shifts)


### PR DESCRIPTION
Closes #590 

The assumptions on which (additional) columns are in a ROI table are not necessary. Now, the helper function just adds the columns "translation_z", "translation_y", "translation_x" and keeps all existing columns.
The behavior is not changing for the FOV_ROI_tables, but now well_ROI_tables should also be supported.

I added a test case for the function itself. It's tricky to build a whole test case around the well_ROI_table that will work reliably (given the way we currently create test data by modifying the original FOV images, a well-based registration isn't expected to work reliably) and `x_micrometer_original` isn't used anywhere else in the task. 

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`

@tcompa Can you have a look and once this is merged, release a 0.13.1 with it?