### PR TITLE
Handle race condition in Apply Registration to image task better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-tasks-core repository.
 
+# Unreleased
+* Improve handling of potential race condition in Apply Registration to image task(\#516).
 
 # 0.14.0
 


### PR DESCRIPTION
@adrtsc I'm proposing a fix here for https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/516 that introduces a `max_retries` parameter. I set it to 20, but we can of course tune that parameter further if needed.

closes #516  

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
