### PR TITLE
Support more than one channel when masking background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-tasks-core repository.
 
-# Unreleased
-* Improve handling of potential race condition in Apply Registration to image task(\#516).
+# 0.14.1
+
+* Improve handling of potential race condition in Apply Registration to image task (\#516).
+* Fix bug in `cellpose_segmentation` upon using masked loading and setting `channel2` (\#639).
 
 # 0.14.0
 

--- a/fractal_tasks_core/masked_loading.py
+++ b/fractal_tasks_core/masked_loading.py
@@ -170,8 +170,9 @@ def _preprocess_input(
         )
 
     # Set image background to zero
-    background_4D = np.expand_dims(background_3D, axis=0)
-    image_array[background_4D] = 0
+    n_channels = image_array.shape[0]
+    for i in range(n_channels):
+        image_array[i, background_3D] = 0
 
     return (image_array, background_3D, current_label_region)
 

--- a/tests/tasks/test_workflows_cellpose_segmentation.py
+++ b/tests/tasks/test_workflows_cellpose_segmentation.py
@@ -971,6 +971,7 @@ def test_workflow_secondary_labeling_no_labels(
             output_label_name="nuclei",
         )
 
+
 def test_workflow_secondary_labeling_two_channels(
     tmp_path: Path,
     testdata_path: Path,

--- a/tests/tasks/test_workflows_cellpose_segmentation.py
+++ b/tests/tasks/test_workflows_cellpose_segmentation.py
@@ -970,3 +970,84 @@ def test_workflow_secondary_labeling_no_labels(
             use_masks=True,
             output_label_name="nuclei",
         )
+
+def test_workflow_secondary_labeling_two_channels(
+    tmp_path: Path,
+    testdata_path: Path,
+    zenodo_zarr: list[str],
+    zenodo_zarr_metadata: list[dict[str, Any]],
+    monkeypatch: MonkeyPatch,
+):
+    """
+    Test that catches issue
+    https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/640,
+    namely the fact the cellpose_segmentation with masked-loading fails when
+    using more than one channel.
+    """
+
+    monkeypatch.setattr(
+        "fractal_tasks_core.tasks.cellpose_segmentation.cellpose.core.use_gpu",
+        patched_cellpose_core_use_gpu,
+    )
+
+    monkeypatch.setattr(
+        "fractal_tasks_core.tasks.cellpose_segmentation.segment_ROI",
+        patched_segment_ROI,
+    )
+
+    # Load pre-made 2D zarr array
+    zarr_path = tmp_path / "tmp_out_mip/"
+    metadata = prepare_2D_zarr(
+        str(zarr_path),
+        zenodo_zarr,
+        zenodo_zarr_metadata,
+        remove_labels=True,
+        make_CYX=False,
+    )
+
+    # Primary segmentation (organoid)
+    for component in metadata["image"]:
+        cellpose_segmentation(
+            input_paths=[str(zarr_path)],
+            output_path=str(zarr_path),
+            metadata=metadata,
+            component=component,
+            channel=ChannelInputModel(wavelength_id="A01_C01"),
+            level=0,
+            relabeling=True,
+            input_ROI_table="FOV_ROI_table",
+            output_label_name="organoids",
+            output_ROI_table="organoid_ROI_table",
+        )
+
+    organoid_ROI_table_path = str(
+        zarr_path / metadata["image"][0] / "tables/organoid_ROI_table"
+    )
+    organoid_ROI_table = ad.read_zarr(organoid_ROI_table_path)
+    organoid_ROI_table_zarr_group = zarr.open(organoid_ROI_table_path)
+    debug(organoid_ROI_table_zarr_group.attrs.asdict())
+    debug(organoid_ROI_table)
+    debug(organoid_ROI_table.X)
+    NUM_LABELS_PER_FOV = 2
+    assert organoid_ROI_table.obs.shape == (NUM_LABELS_PER_FOV * 2, 1)
+    assert organoid_ROI_table.shape == (NUM_LABELS_PER_FOV * 2, 6)
+    assert len(organoid_ROI_table) > 0
+    assert np.max(organoid_ROI_table.X) == float(728)
+
+    debug(zarr_path / metadata["image"][0])
+
+    # Secondary segmentation (nuclei)
+    for component in metadata["image"]:
+        cellpose_segmentation(
+            input_paths=[str(zarr_path)],
+            output_path=str(zarr_path),
+            metadata=metadata,
+            component=component,
+            channel=ChannelInputModel(wavelength_id="A01_C01"),
+            channel2=ChannelInputModel(wavelength_id="A01_C01"),
+            level=0,
+            relabeling=True,
+            input_ROI_table="organoid_ROI_table",
+            use_masks=True,
+            output_label_name="nuclei",
+        )


### PR DESCRIPTION
The original code could only work with one channel input for masking the background. This commit adds support for more than one channel.


## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`


Closes #640 