### PR TITLE
Propagate package argument in create-manifest

### DIFF
--- a/fractal_tasks_core/dev/create_manifest.py
+++ b/fractal_tasks_core/dev/create_manifest.py
@@ -124,6 +124,7 @@ def create_manifest(
         docs_info = create_docs_info(
             executable_non_parallel=task_obj.executable_non_parallel,
             executable_parallel=task_obj.executable_parallel,
+            package=package,
         )
         if docs_info is not None:
             task_dict["docs_info"] = docs_info


### PR DESCRIPTION
This is needed so that other packages can use the create-manifest tool.