### PR TITLE
723 Fix illumination correction task not copying tables

### DIFF
--- a/fractal_tasks_core/tasks/illumination_correction.py
+++ b/fractal_tasks_core/tasks/illumination_correction.py
@@ -34,6 +34,7 @@ from fractal_tasks_core.roi import (
     convert_ROI_table_to_indices,
 )
 from fractal_tasks_core.tasks._zarr_utils import _copy_hcs_ome_zarr_metadata
+from fractal_tasks_core.tasks._zarr_utils import _copy_tables_from_zarr_url
 
 logger = logging.getLogger(__name__)
 
@@ -228,6 +229,9 @@ def illumination_correction(
             dimension_separator="/",
         )
         _copy_hcs_ome_zarr_metadata(zarr_url, zarr_url_new)
+        # Copy ROI tables from the old zarr_url to keep ROI tables and other
+        # tables available in the new Zarr
+        _copy_tables_from_zarr_url(zarr_url, zarr_url_new)
 
     # Iterate over FOV ROIs
     num_ROIs = len(list_indices)

--- a/tests/tasks/test_unit_illumination_correction.py
+++ b/tests/tasks/test_unit_illumination_correction.py
@@ -7,6 +7,7 @@ import anndata as ad
 import dask.array as da
 import numpy as np
 import pytest
+from devtools import debug
 from pytest import LogCaptureFixture
 from pytest import MonkeyPatch
 
@@ -15,6 +16,7 @@ from fractal_tasks_core.ngff.zarr_utils import load_NgffWellMeta
 from fractal_tasks_core.roi import (
     convert_ROI_table_to_indices,
 )
+from fractal_tasks_core.tables.v1 import get_tables_list_v1
 from fractal_tasks_core.tasks._registration_utils import (
     _split_well_path_image_path,
 )
@@ -67,6 +69,9 @@ def test_illumination_correction(
         ROIs, level=0, full_res_pxl_sizes_zyx=pixels
     )
     num_FOVs = len(list_indices)
+
+    # Get existing tables before illumination correction
+    tables = get_tables_list_v1(zarr_url)
 
     # Prepared expected number of calls
     expected_tot_calls_correct = num_channels * num_FOVs
@@ -136,3 +141,9 @@ def test_illumination_correction(
         assert well_paths == ["0"]
     else:
         assert well_paths == ["0", "0" + suffix]
+
+    # Assert that the image has the same tables after illumination correction
+    # as before
+    debug(tables)
+    new_tables = get_tables_list_v1(new_zarr_url)
+    assert tables == new_tables


### PR DESCRIPTION
Illumination correction task now correctly copies tables from the original image
