### PR TITLE
701 import ome zarr fixes

### DIFF
--- a/fractal_tasks_core/tasks/import_ome_zarr.py
+++ b/fractal_tasks_core/tasks/import_ome_zarr.py
@@ -65,8 +65,6 @@ def _process_single_image(
     image_meta = NgffImageMeta(**image_group.attrs.asdict())
 
     # Preliminary checks
-    if not (add_image_ROI_table or add_grid_ROI_table):
-        return
     if add_grid_ROI_table and (grid_YX_shape is None):
         raise ValueError(
             f"_process_single_image called with {add_grid_ROI_table=}, "

--- a/fractal_tasks_core/tasks/import_ome_zarr.py
+++ b/fractal_tasks_core/tasks/import_ome_zarr.py
@@ -261,6 +261,7 @@ def import_ome_zarr(
         for image in root_group.attrs["well"]["images"]:
             image_path = image["path"]
             zarr_url = f"{zarr_path}/{image_path}"
+            well_name = "".join(zarr_path.split("/")[-2:])
             types = _process_single_image(
                 zarr_url,
                 add_image_ROI_table,
@@ -273,7 +274,7 @@ def import_ome_zarr(
                 dict(
                     zarr_url=zarr_url,
                     attributes=dict(
-                        well=zarr_name,
+                        well=well_name,
                     ),
                     types=types,
                 )

--- a/tests/tasks/test_import_ome_zarr.py
+++ b/tests/tasks/test_import_ome_zarr.py
@@ -103,7 +103,7 @@ def test_import_ome_zarr_well(tmp_path, zenodo_zarr):
             {
                 "zarr_url": zarr_urls[0],
                 "attributes": {
-                    "well": "plate.zarr/B/03",
+                    "well": "B03",
                 },
                 "types": {
                     "is_3D": True,

--- a/tests/tasks/test_import_ome_zarr.py
+++ b/tests/tasks/test_import_ome_zarr.py
@@ -3,6 +3,7 @@ import zarr
 from devtools import debug
 
 from .._zenodo_ome_zarrs import prepare_3D_zarr
+from fractal_tasks_core.tables.v1 import get_tables_list_v1
 from fractal_tasks_core.tasks.copy_ome_zarr_hcs_plate import (
     copy_ome_zarr_hcs_plate,
 )
@@ -206,6 +207,62 @@ def test_import_ome_zarr_image_wrong_channels(tmp_path, zenodo_zarr):
         )
     debug(e.value)
     assert "Channels-number mismatch" in str(e.value)
+
+
+def test_import_ome_zarr_plate_no_ROI_tables(tmp_path, zenodo_zarr):
+
+    # Prepare an on-disk OME-Zarr at the plate level
+    zarr_dir = str(tmp_path)
+    prepare_3D_zarr(zarr_dir, zenodo_zarr, remove_tables=True)
+    zarr_name = "plate.zarr"
+
+    # Run import_ome_zarr
+    image_list_changes = import_ome_zarr(
+        zarr_urls=[],
+        zarr_dir=zarr_dir,
+        zarr_name=zarr_name,
+        add_image_ROI_table=False,
+        add_grid_ROI_table=False,
+    )
+    debug(image_list_changes)
+    zarr_urls = [
+        x["zarr_url"] for x in image_list_changes["image_list_updates"]
+    ]
+
+    expected_image_list_changes = {
+        "image_list_updates": [
+            {
+                "zarr_url": zarr_urls[0],
+                "attributes": {
+                    "plate": "plate.zarr",
+                    "well": "B03",
+                },
+                "types": {
+                    "is_3D": True,
+                },
+            },
+        ],
+    }
+    assert expected_image_list_changes == image_list_changes
+
+    # Check that no tables were created
+    assert not get_tables_list_v1(zarr_urls[0])
+
+    # Run copy_ome_zarr and maximum_intensity_projection
+    # to verify that they run without ROI tables
+    parallelization_list = copy_ome_zarr_hcs_plate(
+        zarr_urls=zarr_urls,
+        zarr_dir="tmp_out",
+        overwrite=True,
+    )["parallelization_list"]
+    debug(parallelization_list)
+
+    for image in parallelization_list:
+        maximum_intensity_projection(
+            zarr_url=image["zarr_url"],
+            init_args=image["init_args"],
+            overwrite=True,
+        )
 
 
 # @pytest.mark.skip


### PR DESCRIPTION
Fixes OME-Zarr attributes that are provided. Both when no ROI tables are created & the well-level attributes.

I also reviewed the attributes for plates & images.

Thus, this PR closes #700, closes #701
