### PR TITLE
Fixes for MIP task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
     * Refactor Cellpose Task inputs: Support independent normalization of 2 input channels in the Cellpose task (\#738).
     * Rename `task.cellpose_transforms` into `tasks.cellpose_utils` (\#738).
     * Fix wrong repeated overlap checks for bounding-boxes in Cellpose task (\#778).
+    * Fix minor MIP issues related to plate metadata and expecting acquisition metadata in all NGFF plates(\#781).
+    * Add chi2_shift option to Calculate Registration (image-based) task(\#741).
 * Development:
     * Switch to transitional pydantic.v1 imports, changes pydantic requirement to `==1.10.16` or `>=2.6.3` (\#760).
     * Support JSON-Schema generation for `Enum` task arguments (\#749).
@@ -22,6 +24,8 @@
     * Improve/extend page showing tasks from other packages (\#759, \#777).
 * JSON Schema generation:
     * Test manifest creation for three other tasks packages (\#763).
+* NGFF subpackage
+    * Fix Plate model to correspond better to 0.4.0 NGFF spec: Now makes acquisition metadata optional (\#781).
 
 # 1.0.2
 

--- a/fractal_tasks_core/ngff/specs.py
+++ b/fractal_tasks_core/ngff/specs.py
@@ -446,7 +446,7 @@ class Plate(BaseModel):
     See https://ngff.openmicroscopy.org/0.4/#plate-md.
     """
 
-    acquisitions: list[AcquisitionInPlate]
+    acquisitions: Optional[list[AcquisitionInPlate]]
     columns: list[ColumnInPlate]
     field_count: Optional[int]
     name: Optional[str]

--- a/fractal_tasks_core/tasks/copy_ome_zarr_hcs_plate.py
+++ b/fractal_tasks_core/tasks/copy_ome_zarr_hcs_plate.py
@@ -15,7 +15,6 @@ Task that copies the structure of an OME-NGFF zarr array to a new one.
 import logging
 from typing import Any
 
-import zarr
 from pydantic.v1.decorator import validate_arguments
 
 import fractal_tasks_core
@@ -274,7 +273,7 @@ def copy_ome_zarr_hcs_plate(
 
         # Write well groups:
         for well_sub_url in new_well_image_attrs[old_plate_url]:
-            new_well_group = zarr.group(f"{zarrurl_new}/{well_sub_url}")
+            new_well_group = new_plate_group.create_group(f"{well_sub_url}")
             well_attrs = dict(
                 well=dict(
                     images=[

--- a/tests/tasks/test_workflows.py
+++ b/tests/tasks/test_workflows.py
@@ -312,7 +312,7 @@ def test_MIP(
 ):
 
     # Init
-    zarr_path = tmp_path / "tmp_out/"
+    zarr_path = tmp_path / "tmp_out"
     debug(zarr_path)
 
     # Load zarr array from zenodo
@@ -399,6 +399,14 @@ def test_MIP(
         ).attrs.asdict()
         assert table_attrs["type"] == "roi_table"
         assert table_attrs["fractal_table_version"] == "1"
+
+    # Check correct zarr metadata for row folder (issue #780): Checks that
+    # the one well expected to be in the Zarr plate is discoverable by the
+    # Zarr API
+    plate_zarr_group = zarr.open(plate_zarr)
+    assert len(plate_zarr_group) == 1
+    row_zarr_group = zarr.open(plate_zarr / "B")
+    assert len(row_zarr_group) == 1
 
 
 def test_MIP_subset_of_images(

--- a/tests/tasks/test_workflows.py
+++ b/tests/tasks/test_workflows.py
@@ -313,6 +313,7 @@ def test_MIP(
 
     # Init
     zarr_path = tmp_path / "tmp_out/"
+    debug(zarr_path)
 
     # Load zarr array from zenodo
     zenodo_zarr_3D, zenodo_zarr_2D = zenodo_zarr[:]
@@ -324,7 +325,7 @@ def test_MIP(
 
     parallelization_list = copy_ome_zarr_hcs_plate(
         zarr_urls=zarr_urls,
-        zarr_dir="tmp_out",
+        zarr_dir=str(zarr_path),
         overwrite=True,
     )["parallelization_list"]
     debug(parallelization_list)
@@ -332,7 +333,7 @@ def test_MIP(
     # Run again, with overwrite=True
     parallelization_list_2 = copy_ome_zarr_hcs_plate(
         zarr_urls=zarr_urls,
-        zarr_dir="tmp_out",
+        zarr_dir=str(zarr_path),
         overwrite=True,
     )["parallelization_list"]
     assert parallelization_list_2 == parallelization_list
@@ -341,7 +342,7 @@ def test_MIP(
     with pytest.raises(OverwriteNotAllowedError):
         _ = copy_ome_zarr_hcs_plate(
             zarr_urls=zarr_urls,
-            zarr_dir="tmp_out",
+            zarr_dir=str(zarr_path),
             overwrite=False,
         )
 
@@ -441,7 +442,7 @@ def test_MIP_subset_of_images(
     # Replicate
     parallelization_list = copy_ome_zarr_hcs_plate(
         zarr_urls=zarr_urls,
-        zarr_dir="tmp_out",
+        zarr_dir=str(zarr_dir),
         overwrite=True,
     )["parallelization_list"]
     debug(parallelization_list)


### PR DESCRIPTION
Closes #780 by ensuring correct Zarr metadata is available in new plate Zarr groups

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
