### PR TITLE
Fix for yx images in Cellpose task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Tasks:
     * Fix issue with masked ROI & relabeling in Cellpose task (\#785).
     * Fix issue with masking ROI label types in masked_loading_wrapper for Cellpose task (\#785).
+    * Enable workaround to support yx images in Cellpose task (\#789).
 
 # 1.1.0
 


### PR DESCRIPTION
Closes #788 

This PR contains a small special case handling to enable the Cellpose task to process yx images. Given the current generalizations we've already made, only the channel selection during dask image loading and the metadata updating needed minor adjustment.

With this PR, there are 2 additional checks for those 2 parts that then handle the yx case. It's working well in my local tests on yx data, but we don't currently have yx testing data available.

A cleaner implementation and better testing will come with the ngio work here, I'll already merge this now to unblock user workflows though.

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
