### PR TITLE
Add upper and lower quantile rescaling to calculate_registration_image_based.py for more robust registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-tasks-core repository.
 
+# 1.3.2
+* Tasks:
+    * Add percentile-based rescaling to calculate registration task to make it more robust (\#848)
 * Dependencies:
   * Relax pandas constraint to `<2`.
   * Relax torch constraint to `<=3.0.0`.

--- a/fractal_tasks_core/__FRACTAL_MANIFEST__.json
+++ b/fractal_tasks_core/__FRACTAL_MANIFEST__.json
@@ -1123,6 +1123,18 @@
             "title": "Method",
             "description": "Method to use for image registration. The available methods are `phase_cross_correlation` (scikit-image package, works for 2D & 3D) and \"chi2_shift\" (image_registration package, only works for 2D images)."
           },
+          "lower_rescale_quantile": {
+            "default": 0.0,
+            "title": "Lower Rescale Quantile",
+            "type": "number",
+            "description": "Lower quantile for rescaling the image intensities before applying registration. Can be helpful to deal with image artifacts. Default is 0."
+          },
+          "upper_rescale_quantile": {
+            "default": 0.99,
+            "title": "Upper Rescale Quantile",
+            "type": "number",
+            "description": "Upper quantile for rescaling the image intensities before applying registration. Can be helpful to deal with image artifacts. Default is 0.99."
+          },
           "roi_table": {
             "default": "FOV_ROI_table",
             "title": "Roi Table",

--- a/fractal_tasks_core/tasks/calculate_registration_image_based.py
+++ b/fractal_tasks_core/tasks/calculate_registration_image_based.py
@@ -20,8 +20,8 @@ import dask.array as da
 import numpy as np
 import zarr
 from pydantic import validate_call
-from skimage.registration import phase_cross_correlation
 from skimage.exposure import rescale_intensity
+from skimage.registration import phase_cross_correlation
 
 from fractal_tasks_core.channels import get_channel_from_image_zarr
 from fractal_tasks_core.channels import OmeroChannel

--- a/tests/tasks/test_registration.py
+++ b/tests/tasks/test_registration.py
@@ -237,6 +237,8 @@ def test_multiplexing_registration(
     tmp_path,
     monkeypatch: MonkeyPatch,
     method: str,
+    lower_rescale_quantile: float = 0.0,
+    upper_rescale_quantile: float = 0.99,
     # Given the test data, only implemented per FOV
     roi_table="FOV_ROI_table",
 ):
@@ -348,6 +350,8 @@ def test_multiplexing_registration(
             init_args=image["init_args"],
             wavelength_id="A01_C01",
             method=method,
+            lower_rescale_quantile=lower_rescale_quantile,
+            upper_rescale_quantile=upper_rescale_quantile,
             roi_table=roi_table,
         )
 
@@ -438,6 +442,8 @@ def test_multiplexing_registration_3d(
     tmp_path,
     monkeypatch: MonkeyPatch,
     method: str,
+    lower_rescale_quantile: float = 0.0,
+    upper_rescale_quantile: float = 0.99,
     # Given the test data, only implemented per FOV
     roi_table="FOV_ROI_table",
 ):
@@ -526,6 +532,8 @@ def test_multiplexing_registration_3d(
                     init_args=image["init_args"],
                     wavelength_id="A01_C01",
                     method=method,
+                    lower_rescale_quantile=lower_rescale_quantile,
+                    upper_rescale_quantile=upper_rescale_quantile,
                     roi_table=roi_table,
                 )
             pytest.skip(


### PR DESCRIPTION
After running an old pipeline again on Fractal 2.0, Kelvin reported to me that his registration is worse. Back on Fractal 1.0, he used the apx_fractal_task_collection task for image registration, utilizing the chi2_shift algorithm for shift calculation. In Fractal 2.0, this has been integrated as an additional method in fractal-tasks-core. However, the original apx task additionally did a quantile rescaling, which helped when registering images that had very bright artifacts. This pull request adds a quantile rescaling step to the "Calculate Registration (image-based)" task to restore this behaviour.


## Checklist before merging
- [ ] I added an appropriate entry to `CHANGELOG.md`
