### PR TITLE
Add tasks docs_info

### DIFF
--- a/fractal_tasks_core/dev/task_info/apply_registration_to_image.md
+++ b/fractal_tasks_core/dev/task_info/apply_registration_to_image.md
@@ -1,0 +1,8 @@
+### Purpose
+- Applies pre-calculated registration transformations to images in an HCS OME-Zarr dataset, aligning all acquisitions to a specified reference acquisition.
+- Masks regions not included in the registered ROI table and aligns both intensity and label images.
+- Replaces the non-aligned image with the newly aligned image in the dataset if `overwrite input` is selected.
+- Typically used as the third task in a workflow, following `Calculate Registration (image-based)` and `Find Registration Consensus`.
+
+### Limitations
+- If `overwrite input` is selected, the non-aligned image is permanently deleted, which may impact workflows requiring access to the original images.

--- a/fractal_tasks_core/dev/task_info/calculate_registration_image_based.md
+++ b/fractal_tasks_core/dev/task_info/calculate_registration_image_based.md
@@ -1,0 +1,9 @@
+### Purpose
+- Computes image-based registration transformations for acquisitions in HCS OME-Zarr datasets.
+- Processes images grouped by well, under the assumption that each well contains one image per acquisition.
+- Calculates transformations for specified regions of interest (ROIs) and stores the results in the corresponding ROI table.
+- Typically used as the first task in a workflow, followed by `Find Registration Consensus` and optionally `Apply Registration to Image`.
+
+### Limitations
+- Supports only HCS OME-Zarr datasets, leveraging their acquisition metadata and well-based image grouping.
+- Assumes each well contains a single image per acquisition.

--- a/fractal_tasks_core/dev/task_info/cellpose_segmentation.md
+++ b/fractal_tasks_core/dev/task_info/cellpose_segmentation.md
@@ -1,0 +1,10 @@
+### Purpose
+- Segments images using Cellpose models.
+- Supports both built-in Cellpose models (shipped with Cellpose) and user-trained models.
+- Accepts dual image input for segmentation.
+- Can process arbitrary regions of interest (ROIs), including whole images, fields of view (FOVs), or masked outputs from prior segmentations, based on corresponding ROI tables.
+- Provides access to all advanced Cellpose parameters.
+- Allows custom rescaling options per channel, particularly useful for sparse images.
+
+### Limitations
+- Compatible only with Cellpose 2.x models; does not yet support 3.x models.

--- a/fractal_tasks_core/dev/task_info/convert_cellvoyager_multiplex.md
+++ b/fractal_tasks_core/dev/task_info/convert_cellvoyager_multiplex.md
@@ -1,0 +1,8 @@
+### Purpose
+- Converts multiplexed 2D and 3D images from CellVoyager CV7000/8000 systems into OME-Zarr format, storing each acquisition as a separate OME-Zarr image in the same OME-Zarr plate.
+- Creates OME-Zarr HCS plates, combining all fields of view for each acquisition in a well into a single image.
+- Saves Fractal region-of-interest (ROI) tables for both individual fields of view and the entire well.
+- Handles overlapping fields of view by adjusting their positions to be non-overlapping, while preserving the original position data as additional columns in the ROI tables.
+
+### Limitations
+- This task currently does not support time-resolved data and ignores the time fields in CellVoyager metadata.

--- a/fractal_tasks_core/dev/task_info/convert_cellvoyager_to_ome_zarr.md
+++ b/fractal_tasks_core/dev/task_info/convert_cellvoyager_to_ome_zarr.md
@@ -1,0 +1,8 @@
+### Purpose
+- Converts 2D and 3D images from CellVoyager CV7000/8000 systems into OME-Zarr format, creating OME-Zarr HCS plates and combining all fields of view in a well into a single image.
+- Saves Fractal region-of-interest (ROI) tables for both individual fields of view and the entire well.
+- Handles overlapping fields of view by adjusting their positions to be non-overlapping while retaining the original position data as additional columns in the ROI tables.
+- Supports processing multiple plates in a single task.
+
+### Limitations
+- Currently, this task does not support time-resolved data and ignores the time fields in CellVoyager metadata.

--- a/fractal_tasks_core/dev/task_info/find_registration_consensus.md
+++ b/fractal_tasks_core/dev/task_info/find_registration_consensus.md
@@ -1,0 +1,7 @@
+### Purpose
+- Determines the consensus alignment region across all selected acquisitions within each well of an HCS OME-Zarr dataset.
+- Generates a new ROI table for each image, defining consensus regions that are aligned across all acquisitions.
+- Typically used as the second task in a workflow, following `Calculate Registration (image-based)` and optionally preceding `Apply Registration to Image`.
+
+### Limitations
+- Supports only HCS OME-Zarr datasets, leveraging their acquisition metadata and well-based image grouping.

--- a/fractal_tasks_core/dev/task_info/illumination_correction.md
+++ b/fractal_tasks_core/dev/task_info/illumination_correction.md
@@ -1,0 +1,7 @@
+### Purpose
+- Corrects illumination in OME-Zarr images using pre-calculated flatfield profiles.
+- Optionally performs background subtraction.
+
+### Limitations
+- Requires pre-calculated flatfield profiles in TIFF format.
+- Supports only fixed-value background subtraction; background subtraction profiles are not supported.

--- a/fractal_tasks_core/dev/task_info/import_ome_zarr.md
+++ b/fractal_tasks_core/dev/task_info/import_ome_zarr.md
@@ -1,0 +1,10 @@
+### Purpose
+- Imports a single OME-Zarr dataset into the Fractal framework for further processing.
+- Supports importing either a full OME-Zarr HCS plate or an individual OME-Zarr image.
+- Ensures the OME-Zarr dataset is located in the `zarr_dir` specified by the dataset.
+- Generates the necessary image list metadata required for processing the OME-Zarr with Fractal.
+- Optionally adds new ROI tables to the existing OME-Zarr, enabling compatibility with many other tasks.
+
+### Limitations
+- Supports only OME-Zarr datasets already present in the `zarr_dir` of the corresponding dataset.
+- Assumes the input OME-Zarr is correctly structured and formatted for compatibility with the Fractal framework.

--- a/fractal_tasks_core/dev/task_info/napari_workflows_wrapper.md
+++ b/fractal_tasks_core/dev/task_info/napari_workflows_wrapper.md
@@ -1,0 +1,26 @@
+### Purpose
+- Executes a Napari workflow on the regions of interest (ROIs) within a single OME-NGFF image.
+- Processes specified images and labels as inputs to the workflow, producing outputs such as new labels and data tables.
+- Offers flexibility in defining input and output specifications to customize the workflow for specific datasets and analysis needs.
+
+### Limitations
+- Currently supports only Napari workflows that utilize functions from the `napari-segment-blobs-and-things-with-membranes` module. Other Napari-compatible modules are not supported.
+
+### Input Specifications
+Napari workflows require explicit definitions of input and output data.
+Example of valid `input_specs`:
+```json
+{
+    "in_1": {"type": "image", "channel": {"wavelength_id": "A01_C02"}},
+    "in_2": {"type": "image", "channel": {"label": "DAPI"}},
+    "in_3": {"type": "label", "label_name": "label_DAPI"}
+}
+```
+
+Example of valid `output_specs`:
+```json
+{
+    "out_1": {"type": "label", "label_name": "label_DAPI_new"},
+    "out_2": {"type": "dataframe", "table_name": "measurements"},
+}
+```

--- a/fractal_tasks_core/dev/task_info/projection.md
+++ b/fractal_tasks_core/dev/task_info/projection.md
@@ -1,0 +1,7 @@
+### Purpose
+- Performs Z-axis projection of intensity images using a specified projection method.
+- Generates a new OME-Zarr HCS plate to store the projected data.
+
+### Limitations
+- Supports projections only for OME-Zarr HCS plates; other collections of OME-Zarrs are not yet supported.
+- Currently limited to data in the CZYX format.

--- a/fractal_tasks_core/dev/task_list.py
+++ b/fractal_tasks_core/dev/task_list.py
@@ -25,6 +25,7 @@ TASK_LIST = [
         category="Conversion",
         modality="HCS",
         tags=["Yokogawa", "Cellvoyager"],
+        docs_info="file:task_info/convert_cellvoyager_to_ome_zarr.md",
     ),
     CompoundTask(
         name="Convert Cellvoyager Multiplexing to OME-Zarr",
@@ -35,6 +36,7 @@ TASK_LIST = [
         category="Conversion",
         modality="HCS",
         tags=["Yokogawa", "Cellvoyager"],
+        docs_info="file:task_info/convert_cellvoyager_multiplex.md",
     ),
     CompoundTask(
         name="Project Image (HCS Plate)",
@@ -47,6 +49,7 @@ TASK_LIST = [
         category="Image Processing",
         modality="HCS",
         tags=["Preprocessing"],
+        docs_info="file:task_info/projection.md",
     ),
     ParallelTask(
         name="Illumination Correction",
@@ -56,6 +59,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 1, "mem": 4000},
         category="Image Processing",
         tags=["Preprocessing"],
+        docs_info="file:task_info/illumination_correction.md",
     ),
     ParallelTask(
         name="Cellpose Segmentation",
@@ -67,6 +71,7 @@ TASK_LIST = [
             "Convolutional Neural Network",
             "Instance Segmentation",
         ],
+        docs_info="file:task_info/cellpose_segmentation.md",
     ),
     CompoundTask(
         name="Calculate Registration (image-based)",
@@ -77,6 +82,7 @@ TASK_LIST = [
         category="Registration",
         modality="HCS",
         tags=["Multiplexing"],
+        docs_info="file:task_info/calculate_registration_image_based.md",
     ),
     CompoundTask(
         name="Find Registration Consensus",
@@ -87,6 +93,7 @@ TASK_LIST = [
         category="Registration",
         modality="HCS",
         tags=["Multiplexing"],
+        docs_info="file:task_info/find_registration_consensus.md",
     ),
     ParallelTask(
         name="Apply Registration to Image",
@@ -97,10 +104,12 @@ TASK_LIST = [
         category="Registration",
         modality="HCS",
         tags=["Multiplexing"],
+        docs_info="file:task_info/apply_registration_to_image.md",
     ),
     NonParallelTask(
         name="Import OME-Zarr",
         executable="tasks/import_ome_zarr.py",
+        docs_info="file:task_info/import_ome_zarr.md",
     ),
     ParallelTask(
         name="Napari Workflows Wrapper",
@@ -110,5 +119,6 @@ TASK_LIST = [
             "mem": 32000,
         },
         category="Measurement",
+        docs_info="file:task_info/napari_workflows_wrapper.md",
     ),
 ]


### PR DESCRIPTION
Draft of polished tasks_info for each of the core tasks.

@tcompa This is to address https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/874#issuecomment-2540994246

While setting it up, I started liking the pattern of mostly defining `Purpose` & `Limitations`, but some tasks get extra info. This shows for me that it's indeed valuable to use markdown files, not just strings (as you suggested in the issue).

Can we adapt the manifest building to load the file content if a task contains something like `docs_info="file:task_info/convert_cellvoyager_to_ome_zarr.md"`?

## Checklist before merging
- [ ] I added an appropriate entry to `CHANGELOG.md`
