### PR TITLE
Added optional parameter open_array_kwargs to build_pyramid

### DIFF
--- a/fractal_tasks_core/pyramids.py
+++ b/fractal_tasks_core/pyramids.py
@@ -22,7 +22,7 @@ from typing import Union
 
 import dask.array as da
 import numpy as np
-import zarr
+import zarr.errors
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +106,18 @@ def build_pyramid(
 
         if open_array_kwargs is None:
             open_array_kwargs = {}
+
+        # If overwrite is false, check that the array doesn't exist yet
+        if not overwrite:
+            try:
+                zarr.open(f"{zarrurl}/{ind_level}", mode="r")
+                raise ValueError(
+                    f"While building the pyramids, pyramid level {ind_level} "
+                    "already existed, but `build_pyramid` was called with "
+                    f"{overwrite=}."
+                )
+            except zarr.errors.PathNotFoundError:
+                pass
 
         zarrarr = zarr.open(
             f"{zarrurl}/{ind_level}",

--- a/fractal_tasks_core/pyramids.py
+++ b/fractal_tasks_core/pyramids.py
@@ -14,7 +14,6 @@ Construct and write pyramid of lower-resolution levels.
 """
 import logging
 import pathlib
-import zarr
 from typing import Callable
 from typing import Mapping
 from typing import Optional
@@ -23,6 +22,7 @@ from typing import Union
 
 import dask.array as da
 import numpy as np
+import zarr
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_unit_pyramid_creation.py
+++ b/tests/test_unit_pyramid_creation.py
@@ -68,8 +68,12 @@ def test_build_pyramid(tmp_path):
     # Succeed
     zarrurl = str(tmp_path / "F.zarr")
     da.zeros(shape=(8, 8)).to_zarr(f"{zarrurl}/0")
-    build_pyramid(zarrurl=zarrurl, coarsening_xy=2, num_levels=3,
-        open_array_kwargs={"write_empty_chunks": False, "fill_value": 0})
+    build_pyramid(
+        zarrurl=zarrurl,
+        coarsening_xy=2,
+        num_levels=3,
+        open_array_kwargs={"write_empty_chunks": False, "fill_value": 0},
+    )
     level_1 = da.from_zarr(f"{zarrurl}/1")
     level_2 = da.from_zarr(f"{zarrurl}/2")
     assert level_1.shape == (4, 4)

--- a/tests/test_unit_pyramid_creation.py
+++ b/tests/test_unit_pyramid_creation.py
@@ -81,3 +81,19 @@ def test_build_pyramid(tmp_path):
     # check that the empty chunks are not written to disk
     assert not (tmp_path / "F.zarr/1/0.0").exists()
     assert not (tmp_path / "F.zarr/2/0.0").exists()
+
+
+def test_build_pyramid_overwrite(tmp_path):
+    # Succeed
+    zarrurl = str(tmp_path / "D.zarr")
+    da.ones(shape=(8, 8)).to_zarr(f"{zarrurl}/0")
+    build_pyramid(zarrurl=zarrurl, coarsening_xy=2, num_levels=3)
+    # Should fail because overwrite is not set
+    with pytest.raises(ValueError):
+        build_pyramid(
+            zarrurl=zarrurl, coarsening_xy=2, num_levels=3, overwrite=False
+        )
+    # Should work
+    build_pyramid(
+        zarrurl=zarrurl, coarsening_xy=2, num_levels=3, overwrite=True
+    )

--- a/tests/test_unit_pyramid_creation.py
+++ b/tests/test_unit_pyramid_creation.py
@@ -64,3 +64,16 @@ def test_build_pyramid(tmp_path):
     assert level_3.chunksize == (9, 9)
     assert level_4.shape == (3, 3)
     assert level_5.shape == (1, 1)
+
+    # Succeed
+    zarrurl = str(tmp_path / "F.zarr")
+    da.zeros(shape=(8, 8)).to_zarr(f"{zarrurl}/0")
+    build_pyramid(zarrurl=zarrurl, coarsening_xy=2, num_levels=3,
+        open_array_kwargs={"write_empty_chunks": False, "fill_value": 0})
+    level_1 = da.from_zarr(f"{zarrurl}/1")
+    level_2 = da.from_zarr(f"{zarrurl}/2")
+    assert level_1.shape == (4, 4)
+    assert level_2.shape == (2, 2)
+    # check that the empty chunks are not written to disk
+    assert not (tmp_path / "F.zarr/1/0.0").exists()
+    assert not (tmp_path / "F.zarr/2/0.0").exists()


### PR DESCRIPTION
… to be passed as kwargs to zarr.open when creating the pyramid level arrays.

Useful e.g. for passing `write_empty_chunks=True`.

Fixes https://github.com/fractal-analytics-platform/fractal-tasks-core/issues/894.


## Checklist before merging
- [ ] I added an appropriate entry to `CHANGELOG.md`
