### PR TITLE
Fix pyramid directory store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-tasks-core repository.
 
+# 1.4.3
+* Library
+    * Ensure build_pyramid uses directory store by default (\#902).
+
 # 1.4.2
 * Dependencies:
     * Relax from `0.1.4` to `>=0.1.5,<0.2.0`

--- a/fractal_tasks_core/pyramids.py
+++ b/fractal_tasks_core/pyramids.py
@@ -125,6 +125,9 @@ def build_pyramid(
             chunks=newlevel_rechunked.chunksize,
             dtype=newlevel_rechunked.dtype,
             mode="w",
+            dimension_separator=open_array_kwargs.get(
+                "dimension_separator", "/"
+            ),
             **open_array_kwargs,
         )
 
@@ -135,5 +138,7 @@ def build_pyramid(
             compute=True,
             return_stored=True,
             write_empty_chunks=False,
-            dimension_separator="/",
+            dimension_separator=open_array_kwargs.get(
+                "dimension_separator", "/"
+            ),
         )


### PR DESCRIPTION
This reverts build_pyramid back to the behavior we had before 1.4.1
All the tests passed with 1.4.1, because apparently our Zarr API calls handle this fine. But the napari-ome-zarr plugin doesn't load arrays stored with the . store.

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
