### PR TITLE
Fix table copying in apply_registration_to_image task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
         * `import_ome_zarr`: default `table_backend` for `image_ROI_table`/`grid_ROI_table` is now `"csv"` (was `"anndata"`).
         * `threshold_segmentation`'s `CreateMaskingRoiTable`: default `table_backend` is now `"csv"` (was `"anndata"`).
         * `projection`/`compute_projection_hcs`: confirmed (no code change needed) that the projected image's ROI tables already preserve the input image's table backend, and added regression tests for this.
+    * Refactor `import_ome_zarr` task interface (\#1063):
+        * `update_omero_metadata`, `add_image_roi_table`, and `add_grid_roi_table` now default to `False` (previously `True`), so ROI-table/metadata creation is now opt-in.
+        * All parameters after `zarr_name` are now grouped into a single `advanced_options: AdvancedOptions` argument.
+        * `add_grid_roi_table`/`grid_y_shape`/`grid_x_shape` are replaced by `advanced_options.grid_roi_table: GridRoiTable | None`; set it to build a `grid_ROI_table`, leave it `None` to skip it.
     * Fix table copying in `apply_registration_to_image` task: Use the existing table backend for the newly written table, perform table writing outside the try/except loop to catch reading race conditions and provide reading exception in the Runtime Error (\#1063).
 * Chore:
     * Handle deprecation warnings in ngio (\#1063).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # 2.0.3
 * Tasks:
     * Fix table copying in `apply_registration_to_image` task: Use the existing table backend for the newly written table, perform table writing outside the try/except loop to catch reading race conditions and provide reading exception in the Runtime Error (\#1063).
+* Chore:
+    * Handle deprecation warnings in ngio (\#1063).
 * Documentation:
     * Remove `extra_javascript` from docs (\#1055).
     * Move from `mkdocs` to `zensical` (\#1060).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-tasks-core repository.
 
-# Unreleased
+# 2.0.3
+* Tasks:
+    * Fix table copying in `apply_registration_to_image` task: Use the existing table backend for the newly written table, perform table writing outside the try/except loop to catch reading race conditions and provide reading exception in the Runtime Error (\#1063).
 * Documentation:
     * Remove `extra_javascript` from docs (\#1055).
     * Move from `mkdocs` to `zensical` (\#1060).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-tasks-core repository.
 
-# 2.0.3
+# 2.1.0
 * Tasks:
+    * Change default table backends to better fit each task's data (\#1063):
+        * `measure_features`: default `table_backend` is now `"parquet"` (was `"anndata"`).
+        * `import_ome_zarr`: default `table_backend` for `image_ROI_table`/`grid_ROI_table` is now `"csv"` (was `"anndata"`).
+        * `threshold_segmentation`'s `CreateMaskingRoiTable`: default `table_backend` is now `"csv"` (was `"anndata"`).
+        * `projection`/`compute_projection_hcs`: confirmed (no code change needed) that the projected image's ROI tables already preserve the input image's table backend, and added regression tests for this.
     * Fix table copying in `apply_registration_to_image` task: Use the existing table backend for the newly written table, perform table writing outside the try/except loop to catch reading race conditions and provide reading exception in the Runtime Error (\#1063).
 * Chore:
     * Handle deprecation warnings in ngio (\#1063).

--- a/fractal_tasks_core/__FRACTAL_MANIFEST__.json
+++ b/fractal_tasks_core/__FRACTAL_MANIFEST__.json
@@ -1458,6 +1458,77 @@
       "type": "converter_non_parallel",
       "executable_non_parallel": "import_ome_zarr.py",
       "args_schema_non_parallel": {
+        "$defs": {
+          "AdvancedOptions": {
+            "description": "Advanced options for importing an OME-Zarr.",
+            "properties": {
+              "update_omero_metadata": {
+                "default": false,
+                "description": "Whether to update Omero-channels metadata with channel labels and\nwavelength ids to make them compatible with some downstream Fractal tasks.",
+                "title": "Update Omero Metadata",
+                "type": "boolean"
+              },
+              "add_image_roi_table": {
+                "default": false,
+                "description": "Whether to add an `image_ROI_table` table to each image, with a single ROI\ncovering the whole image.",
+                "title": "Add Image Roi Table",
+                "type": "boolean"
+              },
+              "grid_roi_table": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/GridRoiTable"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "If set, add a `grid_ROI_table` table to each image, with the image split\ninto a rectangular grid of ROIs of the given shape. If `None`, no\n`grid_ROI_table` is created.",
+                "title": "Grid_Roi_Table"
+              },
+              "table_backend": {
+                "default": "csv",
+                "description": "Table backend to use for the new ROI tables. Defaults to \"csv\".",
+                "enum": [
+                  "anndata",
+                  "json",
+                  "csv",
+                  "parquet"
+                ],
+                "title": "Table Backend",
+                "type": "string"
+              },
+              "overwrite": {
+                "default": false,
+                "description": "Whether new ROI tables (added when `add_image_roi_table=True` and/or\n`grid_roi_table` is not `None`) can overwrite existing ones.",
+                "title": "Overwrite",
+                "type": "boolean"
+              }
+            },
+            "title": "AdvancedOptions",
+            "type": "object"
+          },
+          "GridRoiTable": {
+            "description": "Configuration for building a `grid_ROI_table`.",
+            "properties": {
+              "grid_y_shape": {
+                "default": 2,
+                "description": "Number of ROIs along the Y axis. The image is split into a `grid_y_shape` by\n`grid_x_shape` grid of ROIs (e.g. the default 2 by 2 produces 4 ROIs).",
+                "title": "Grid Y Shape",
+                "type": "integer"
+              },
+              "grid_x_shape": {
+                "default": 2,
+                "description": "Number of ROIs along the X axis. The image is split into a `grid_y_shape` by\n`grid_x_shape` grid of ROIs (e.g. the default 2 by 2 produces 4 ROIs).",
+                "title": "Grid X Shape",
+                "type": "integer"
+              }
+            },
+            "title": "GridRoiTable",
+            "type": "object"
+          }
+        },
         "additionalProperties": false,
         "properties": {
           "zarr_dir": {
@@ -1470,53 +1541,17 @@
             "type": "string",
             "description": "The OME-Zarr name, without its parent folder. The parent folder is provided by zarr_dir; e.g. `zarr_name=\"array.zarr\"`, if the OME-Zarr path is in `/zarr_dir/array.zarr`."
           },
-          "update_omero_metadata": {
-            "default": true,
-            "title": "Update Omero Metadata",
-            "type": "boolean",
-            "description": "Whether to update Omero-channels metadata, to make them Fractal-compatible."
-          },
-          "add_image_roi_table": {
-            "default": true,
-            "title": "Add Image Roi Table",
-            "type": "boolean",
-            "description": "Whether to add a `image_ROI_table` table to each image, with a single ROI covering the whole image."
-          },
-          "add_grid_roi_table": {
-            "default": true,
-            "title": "Add Grid Roi Table",
-            "type": "boolean",
-            "description": "Whether to add a `grid_ROI_table` table to each image, with the image split into a rectangular grid of ROIs."
-          },
-          "grid_y_shape": {
-            "default": 2,
-            "title": "Grid Y Shape",
-            "type": "integer",
-            "description": "Number of ROIs along the Y axis of `grid_ROI_table`. The image is split into a `grid_y_shape` by `grid_x_shape` grid of ROIs (e.g. the default 2 by 2 produces 4 ROIs)."
-          },
-          "grid_x_shape": {
-            "default": 2,
-            "title": "Grid X Shape",
-            "type": "integer",
-            "description": "Number of ROIs along the X axis of `grid_ROI_table`. The image is split into a `grid_y_shape` by `grid_x_shape` grid of ROIs (e.g. the default 2 by 2 produces 4 ROIs)."
-          },
-          "table_backend": {
-            "default": "csv",
-            "enum": [
-              "anndata",
-              "json",
-              "csv",
-              "parquet"
-            ],
-            "title": "Table Backend",
-            "type": "string",
-            "description": "Backend to use for the new ROI tables. Defaults to \"csv\"."
-          },
-          "overwrite": {
-            "default": false,
-            "title": "Overwrite",
-            "type": "boolean",
-            "description": "Whether new ROI tables (added when `add_image_roi_table` and/or `add_grid_roi_table` are `True`) can overwrite existing ones."
+          "advanced_options": {
+            "$ref": "#/$defs/AdvancedOptions",
+            "default": {
+              "update_omero_metadata": false,
+              "add_image_roi_table": false,
+              "grid_roi_table": null,
+              "table_backend": "csv",
+              "overwrite": false
+            },
+            "title": "Advanced Options",
+            "description": "Advanced options for importing an OME-Zarr, including whether to add `image_ROI_table`/`grid_ROI_table` tables, whether to update Omero-channels metadata, the table backend to use, and whether new tables can overwrite existing ones."
           }
         },
         "required": [

--- a/fractal_tasks_core/__FRACTAL_MANIFEST__.json
+++ b/fractal_tasks_core/__FRACTAL_MANIFEST__.json
@@ -418,8 +418,8 @@
                 "type": "string"
               },
               "table_backend": {
-                "default": "anndata",
-                "description": "Backend to use for storing the masking ROI table. Options are \"anndata\", \"json\",\n\"csv\", and \"parquet\".",
+                "default": "csv",
+                "description": "Backend to use for storing the masking ROI table. Options are \"anndata\", \"json\",\n\"csv\", and \"parquet\". Defaults to \"csv\".",
                 "enum": [
                   "anndata",
                   "json",
@@ -961,8 +961,8 @@
                 "type": "boolean"
               },
               "table_backend": {
-                "default": "anndata",
-                "description": "Table backend to use for the output table. Defaults to \"anndata\".",
+                "default": "parquet",
+                "description": "Table backend to use for the output table. Defaults to \"parquet\".",
                 "enum": [
                   "anndata",
                   "json",
@@ -1122,7 +1122,7 @@
               "level_path": null,
               "use_scaling": true,
               "use_cache": true,
-              "table_backend": "anndata"
+              "table_backend": "parquet"
             },
             "title": "Advanced Options",
             "description": "Advanced options for feature measurement."
@@ -1501,7 +1501,7 @@
             "description": "Number of ROIs along the X axis of `grid_ROI_table`. The image is split into a `grid_y_shape` by `grid_x_shape` grid of ROIs (e.g. the default 2 by 2 produces 4 ROIs)."
           },
           "table_backend": {
-            "default": "anndata",
+            "default": "csv",
             "enum": [
               "anndata",
               "json",
@@ -1510,7 +1510,7 @@
             ],
             "title": "Table Backend",
             "type": "string",
-            "description": "Backend to use for the new ROI tables. Defaults to \"anndata\"."
+            "description": "Backend to use for the new ROI tables. Defaults to \"csv\"."
           },
           "overwrite": {
             "default": false,

--- a/fractal_tasks_core/_import_ome_zarr_utils.py
+++ b/fractal_tasks_core/_import_ome_zarr_utils.py
@@ -1,0 +1,56 @@
+# Copyright 2022-2026 (C) BioVisionCenter, University of Zurich
+"""Pydantic models for the import_ome_zarr task."""
+
+from pydantic import BaseModel
+
+from fractal_tasks_core._utils import AVAILABLE_TABLE_BACKENDS
+
+
+class GridRoiTable(BaseModel):
+    """Configuration for building a `grid_ROI_table`."""
+
+    grid_y_shape: int = 2
+    """
+    Number of ROIs along the Y axis. The image is split into a `grid_y_shape` by
+    `grid_x_shape` grid of ROIs (e.g. the default 2 by 2 produces 4 ROIs).
+    """
+
+    grid_x_shape: int = 2
+    """
+    Number of ROIs along the X axis. The image is split into a `grid_y_shape` by
+    `grid_x_shape` grid of ROIs (e.g. the default 2 by 2 produces 4 ROIs).
+    """
+
+
+class AdvancedOptions(BaseModel):
+    """Advanced options for importing an OME-Zarr."""
+
+    update_omero_metadata: bool = False
+    """
+    Whether to update Omero-channels metadata with channel labels and
+    wavelength ids to make them compatible with some downstream Fractal tasks.
+    """
+
+    add_image_roi_table: bool = False
+    """
+    Whether to add an `image_ROI_table` table to each image, with a single ROI
+    covering the whole image.
+    """
+
+    grid_roi_table: GridRoiTable | None = None
+    """
+    If set, add a `grid_ROI_table` table to each image, with the image split
+    into a rectangular grid of ROIs of the given shape. If `None`, no
+    `grid_ROI_table` is created.
+    """
+
+    table_backend: AVAILABLE_TABLE_BACKENDS = "csv"
+    """
+    Table backend to use for the new ROI tables. Defaults to "csv".
+    """
+
+    overwrite: bool = False
+    """
+    Whether new ROI tables (added when `add_image_roi_table=True` and/or
+    `grid_roi_table` is not `None`) can overwrite existing ones.
+    """

--- a/fractal_tasks_core/_measure_features_utils.py
+++ b/fractal_tasks_core/_measure_features_utils.py
@@ -12,7 +12,7 @@ from ngio import (
 from pydantic import BaseModel, Field
 from skimage import measure
 
-from fractal_tasks_core._utils import AVAILABLE_TABLE_BACKENDS, DEFAULT_TABLE_BACKEND
+from fractal_tasks_core._utils import AVAILABLE_TABLE_BACKENDS
 
 
 class ShapeFeatures(BaseModel):
@@ -155,9 +155,9 @@ class AdvancedOptions(BaseModel):
     but can also increase memory usage. Defaults to True.
     """
 
-    table_backend: AVAILABLE_TABLE_BACKENDS = DEFAULT_TABLE_BACKEND
+    table_backend: AVAILABLE_TABLE_BACKENDS = "parquet"
     """
-    Table backend to use for the output table. Defaults to "anndata".
+    Table backend to use for the output table. Defaults to "parquet".
     """
 
 

--- a/fractal_tasks_core/_threshold_segmentation_utils.py
+++ b/fractal_tasks_core/_threshold_segmentation_utils.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from skimage.filters import threshold_otsu
 from skimage.measure import label
 
-from fractal_tasks_core._utils import AVAILABLE_TABLE_BACKENDS, DEFAULT_TABLE_BACKEND
+from fractal_tasks_core._utils import AVAILABLE_TABLE_BACKENDS
 
 logger = logging.getLogger("threshold_segmentation_task_utils")
 
@@ -32,10 +32,10 @@ class CreateMaskingRoiTable(BaseModel):
     "{output_label_name}", which will be replaced by the name of the label image used
     for segmentation.
     """
-    table_backend: AVAILABLE_TABLE_BACKENDS = DEFAULT_TABLE_BACKEND
+    table_backend: AVAILABLE_TABLE_BACKENDS = "csv"
     """
     Backend to use for storing the masking ROI table. Options are "anndata", "json",
-    "csv", and "parquet".
+    "csv", and "parquet". Defaults to "csv".
     """
 
     def get_table_name(self, output_label_name: str) -> str:

--- a/fractal_tasks_core/_utils.py
+++ b/fractal_tasks_core/_utils.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
 AVAILABLE_TABLE_BACKENDS: TypeAlias = Literal["anndata", "json", "csv", "parquet"]
-DEFAULT_TABLE_BACKEND: AVAILABLE_TABLE_BACKENDS = "anndata"
 
 
 @dataclass

--- a/fractal_tasks_core/apply_registration_to_image.py
+++ b/fractal_tasks_core/apply_registration_to_image.py
@@ -254,12 +254,13 @@ def apply_registration_to_image(
         for table_name, source in tables_to_copy.items():
             logger.info(f"Copying table: {table_name}")
             # Retry loop to guard against race conditions (see issue #516)
+            last_exception: Exception | None = None
             for attempt in range(max_retries):
                 try:
                     table = source.get_table(table_name)
-                    new_ome_zarr.add_table(name=table_name, table=table, overwrite=True)
                     break
-                except Exception:
+                except Exception as e:
+                    last_exception = e
                     logger.debug(
                         f"Table {table_name} not found in attempt {attempt}. "
                         f"Waiting {sleep_time} seconds before trying again."
@@ -267,10 +268,24 @@ def apply_registration_to_image(
                     time.sleep(sleep_time)
             else:
                 raise RuntimeError(
-                    f"Table {table_name} not found after {max_retries} attempts. "
-                    "Check whether this table actually exists. If it does, "
-                    "this may be a race condition issue."
+                    f"Table {table_name} could not be loaded after "
+                    f"{max_retries} attempts. "
+                    f"The original error was: {last_exception}"
+                ) from last_exception
+            # Writing table outside of the retry loop intentionally. We only
+            # want to catch loading race conditions above, not real writing
+            # errors.
+            # Only overwrite the backend if it is set before (which should 
+            # always be the case for loaded tables)
+            if table.backend_name:
+                new_ome_zarr.add_table(
+                    name=table_name,
+                    table=table,
+                    backend=table.backend_name,
+                    overwrite=True,
                 )
+            else:
+                new_ome_zarr.add_table(name=table_name, table=table, overwrite=True)
 
     ####################
     # Clean up Zarr file

--- a/fractal_tasks_core/apply_registration_to_image.py
+++ b/fractal_tasks_core/apply_registration_to_image.py
@@ -275,7 +275,7 @@ def apply_registration_to_image(
             # Writing table outside of the retry loop intentionally. We only
             # want to catch loading race conditions above, not real writing
             # errors.
-            # Only overwrite the backend if it is set before (which should 
+            # Only overwrite the backend if it is set before (which should
             # always be the case for loaded tables)
             if table.backend_name:
                 new_ome_zarr.add_table(

--- a/fractal_tasks_core/import_ome_zarr.py
+++ b/fractal_tasks_core/import_ome_zarr.py
@@ -16,8 +16,9 @@ from ngio import (
 )
 from ngio.ome_zarr_meta.ngio_specs import ChannelsMeta
 from ngio.tables import RoiTable
-from pydantic import validate_call
+from pydantic import Field, validate_call
 
+from fractal_tasks_core._import_ome_zarr_utils import AdvancedOptions
 from fractal_tasks_core._utils import AVAILABLE_TABLE_BACKENDS
 
 logger = logging.getLogger("import_ome_zarr")
@@ -89,46 +90,36 @@ def _process_single_image(
     *,
     zarr_path: str,
     ome_zarr_image: OmeZarrContainer,
-    add_image_roi_table: bool,
-    add_grid_roi_table: bool,
-    update_omero_metadata: bool,
-    grid_YX_shape: tuple[int, int] | None = None,
+    advanced_options: AdvancedOptions,
     attributes: dict[str, Any] | None = None,
-    table_backend: AVAILABLE_TABLE_BACKENDS = "csv",
-    overwrite: bool = False,
 ) -> list[dict[str, Any]]:
     """Optionally generate ROI tables and update omero metadata for a single image.
 
     Args:
         zarr_path: Absolute path to the image Zarr group.
         ome_zarr_image: OME-Zarr image container.
-        add_image_roi_table: Whether to add an `image_ROI_table` table.
-        add_grid_roi_table: Whether to add a `grid_ROI_table` table.
-        update_omero_metadata: Whether to update Omero-channels metadata.
-        grid_YX_shape: YX shape of the ROI grid (must not be `None` when
-            `add_grid_roi_table=True`).
+        advanced_options: Advanced options for the import.
         attributes: Optional image attributes to include in the update dict.
-        table_backend: Backend to use for the new ROI tables.
-        overwrite: Whether to overwrite existing ROI tables.
     """
-    if add_image_roi_table:
+    if advanced_options.add_image_roi_table:
         table = ome_zarr_image.build_image_roi_table()
         ome_zarr_image.add_table(
             name="image_ROI_table",
             table=table,
-            overwrite=overwrite,
-            backend=table_backend,
+            overwrite=advanced_options.overwrite,
+            backend=advanced_options.table_backend,
         )
 
-    if add_grid_roi_table:
+    if advanced_options.grid_roi_table is not None:
+        grid_roi_table = advanced_options.grid_roi_table
         _build_xy_roi_table(
             ome_zarr_image=ome_zarr_image,
-            grid_YX_shape=grid_YX_shape,
-            overwrite=overwrite,
-            backend=table_backend,
+            grid_YX_shape=(grid_roi_table.grid_y_shape, grid_roi_table.grid_x_shape),
+            overwrite=advanced_options.overwrite,
+            backend=advanced_options.table_backend,
         )
 
-    if update_omero_metadata:
+    if advanced_options.update_omero_metadata:
         image = ome_zarr_image.get_image()
         channel_names = image.channel_labels
         wavelengths = image.channels_meta.channel_wavelength_ids
@@ -157,12 +148,7 @@ def _process_well(
     *,
     zarr_path: str,
     ome_zarr_well: OmeZarrWell,
-    add_image_roi_table: bool,
-    add_grid_roi_table: bool,
-    update_omero_metadata: bool,
-    grid_YX_shape: tuple[int, int] | None = None,
-    table_backend: AVAILABLE_TABLE_BACKENDS = "csv",
-    overwrite: bool = False,
+    advanced_options: AdvancedOptions,
 ) -> list[dict[str, Any]]:
     """For each image in the well, create an image list update dict."""
     image_list_updates = []
@@ -176,13 +162,8 @@ def _process_well(
         _updates = _process_single_image(
             zarr_path=image_zarr_path,
             ome_zarr_image=ome_zarr_image,
-            add_image_roi_table=add_image_roi_table,
-            add_grid_roi_table=add_grid_roi_table,
-            update_omero_metadata=update_omero_metadata,
-            grid_YX_shape=grid_YX_shape,
+            advanced_options=advanced_options,
             attributes=attributes,
-            table_backend=table_backend,
-            overwrite=overwrite,
         )
         image_list_updates.extend(_updates)
     return image_list_updates
@@ -192,12 +173,7 @@ def _process_plate(
     *,
     zarr_path: str,
     ome_zarr_plate: OmeZarrPlate,
-    add_image_roi_table: bool,
-    add_grid_roi_table: bool,
-    update_omero_metadata: bool,
-    grid_YX_shape: tuple[int, int] | None = None,
-    table_backend: AVAILABLE_TABLE_BACKENDS = "csv",
-    overwrite: bool = False,
+    advanced_options: AdvancedOptions,
 ) -> list[dict[str, Any]]:
     """For each image in the plate, create an image list update dict."""
     image_list_updates = []
@@ -213,13 +189,8 @@ def _process_plate(
         _updates = _process_single_image(
             zarr_path=image_zarr_path,
             ome_zarr_image=image,
-            add_image_roi_table=add_image_roi_table,
-            add_grid_roi_table=add_grid_roi_table,
-            update_omero_metadata=update_omero_metadata,
-            grid_YX_shape=grid_YX_shape,
+            advanced_options=advanced_options,
             attributes=attributes,
-            overwrite=overwrite,
-            table_backend=table_backend,
         )
         image_list_updates.extend(_updates)
     return image_list_updates
@@ -270,15 +241,7 @@ def import_ome_zarr(
     zarr_dir: str,
     # Core parameters
     zarr_name: str,
-    update_omero_metadata: bool = True,
-    add_image_roi_table: bool = True,
-    add_grid_roi_table: bool = True,
-    # Advanced parameters
-    grid_y_shape: int = 2,
-    grid_x_shape: int = 2,
-    table_backend: AVAILABLE_TABLE_BACKENDS = "csv",
-    # Other parameters
-    overwrite: bool = False,
+    advanced_options: AdvancedOptions = Field(default_factory=AdvancedOptions),
 ) -> dict[str, Any]:
     """Import a single OME-Zarr into Fractal.
 
@@ -294,21 +257,10 @@ def import_ome_zarr(
         zarr_name: The OME-Zarr name, without its parent folder. The parent
             folder is provided by zarr_dir; e.g. `zarr_name="array.zarr"`,
             if the OME-Zarr path is in `/zarr_dir/array.zarr`.
-        add_image_roi_table: Whether to add a `image_ROI_table` table to each
-            image, with a single ROI covering the whole image.
-        add_grid_roi_table: Whether to add a `grid_ROI_table` table to each
-            image, with the image split into a rectangular grid of ROIs.
-        grid_y_shape: Number of ROIs along the Y axis of `grid_ROI_table`. The
-            image is split into a `grid_y_shape` by `grid_x_shape` grid of ROIs
-            (e.g. the default 2 by 2 produces 4 ROIs).
-        grid_x_shape: Number of ROIs along the X axis of `grid_ROI_table`. The
-            image is split into a `grid_y_shape` by `grid_x_shape` grid of ROIs
-            (e.g. the default 2 by 2 produces 4 ROIs).
-        table_backend: Backend to use for the new ROI tables. Defaults to "csv".
-        update_omero_metadata: Whether to update Omero-channels metadata, to
-            make them Fractal-compatible.
-        overwrite: Whether new ROI tables (added when `add_image_roi_table`
-            and/or `add_grid_roi_table` are `True`) can overwrite existing ones.
+        advanced_options: Advanced options for importing an OME-Zarr, including
+            whether to add `image_ROI_table`/`grid_ROI_table` tables, whether
+            to update Omero-channels metadata, the table backend to use, and
+            whether new tables can overwrite existing ones.
     """
     zarr_path = f"{zarr_dir.rstrip('/')}/{zarr_name}"
     logger.info(f"Zarr path: {zarr_path}")
@@ -319,34 +271,19 @@ def import_ome_zarr(
         image_list_updates = _process_plate(
             zarr_path=zarr_path,
             ome_zarr_plate=ome_zarr,
-            add_image_roi_table=add_image_roi_table,
-            add_grid_roi_table=add_grid_roi_table,
-            update_omero_metadata=update_omero_metadata,
-            grid_YX_shape=(grid_y_shape, grid_x_shape),
-            table_backend=table_backend,
-            overwrite=overwrite,
+            advanced_options=advanced_options,
         )
     elif isinstance(ome_zarr, OmeZarrWell):
         image_list_updates = _process_well(
             zarr_path=zarr_path,
             ome_zarr_well=ome_zarr,
-            add_image_roi_table=add_image_roi_table,
-            add_grid_roi_table=add_grid_roi_table,
-            update_omero_metadata=update_omero_metadata,
-            grid_YX_shape=(grid_y_shape, grid_x_shape),
-            table_backend=table_backend,
-            overwrite=overwrite,
+            advanced_options=advanced_options,
         )
     elif isinstance(ome_zarr, OmeZarrContainer):
         image_list_updates = _process_single_image(
             zarr_path=zarr_path,
             ome_zarr_image=ome_zarr,
-            add_image_roi_table=add_image_roi_table,
-            add_grid_roi_table=add_grid_roi_table,
-            update_omero_metadata=update_omero_metadata,
-            grid_YX_shape=(grid_y_shape, grid_x_shape),
-            table_backend=table_backend,
-            overwrite=overwrite,
+            advanced_options=advanced_options,
         )
     else:
         raise ValueError(

--- a/fractal_tasks_core/import_ome_zarr.py
+++ b/fractal_tasks_core/import_ome_zarr.py
@@ -18,7 +18,7 @@ from ngio.ome_zarr_meta.ngio_specs import ChannelsMeta
 from ngio.tables import RoiTable
 from pydantic import validate_call
 
-from fractal_tasks_core._utils import AVAILABLE_TABLE_BACKENDS, DEFAULT_TABLE_BACKEND
+from fractal_tasks_core._utils import AVAILABLE_TABLE_BACKENDS
 
 logger = logging.getLogger("import_ome_zarr")
 
@@ -26,7 +26,7 @@ logger = logging.getLogger("import_ome_zarr")
 def _build_xy_roi_table(
     ome_zarr_image: OmeZarrContainer,
     grid_YX_shape: tuple[int, int] | None = None,
-    backend: AVAILABLE_TABLE_BACKENDS = DEFAULT_TABLE_BACKEND,
+    backend: AVAILABLE_TABLE_BACKENDS = "csv",
     overwrite: bool = False,
 ) -> None:
     """Build a grid_ROI_table with a rectangular grid of ROIs covering the whole image.
@@ -94,7 +94,7 @@ def _process_single_image(
     update_omero_metadata: bool,
     grid_YX_shape: tuple[int, int] | None = None,
     attributes: dict[str, Any] | None = None,
-    table_backend: AVAILABLE_TABLE_BACKENDS = DEFAULT_TABLE_BACKEND,
+    table_backend: AVAILABLE_TABLE_BACKENDS = "csv",
     overwrite: bool = False,
 ) -> list[dict[str, Any]]:
     """Optionally generate ROI tables and update omero metadata for a single image.
@@ -161,7 +161,7 @@ def _process_well(
     add_grid_roi_table: bool,
     update_omero_metadata: bool,
     grid_YX_shape: tuple[int, int] | None = None,
-    table_backend: AVAILABLE_TABLE_BACKENDS = DEFAULT_TABLE_BACKEND,
+    table_backend: AVAILABLE_TABLE_BACKENDS = "csv",
     overwrite: bool = False,
 ) -> list[dict[str, Any]]:
     """For each image in the well, create an image list update dict."""
@@ -196,7 +196,7 @@ def _process_plate(
     add_grid_roi_table: bool,
     update_omero_metadata: bool,
     grid_YX_shape: tuple[int, int] | None = None,
-    table_backend: AVAILABLE_TABLE_BACKENDS = DEFAULT_TABLE_BACKEND,
+    table_backend: AVAILABLE_TABLE_BACKENDS = "csv",
     overwrite: bool = False,
 ) -> list[dict[str, Any]]:
     """For each image in the plate, create an image list update dict."""
@@ -276,7 +276,7 @@ def import_ome_zarr(
     # Advanced parameters
     grid_y_shape: int = 2,
     grid_x_shape: int = 2,
-    table_backend: AVAILABLE_TABLE_BACKENDS = DEFAULT_TABLE_BACKEND,
+    table_backend: AVAILABLE_TABLE_BACKENDS = "csv",
     # Other parameters
     overwrite: bool = False,
 ) -> dict[str, Any]:
@@ -304,7 +304,7 @@ def import_ome_zarr(
         grid_x_shape: Number of ROIs along the X axis of `grid_ROI_table`. The
             image is split into a `grid_y_shape` by `grid_x_shape` grid of ROIs
             (e.g. the default 2 by 2 produces 4 ROIs).
-        table_backend: Backend to use for the new ROI tables. Defaults to "anndata".
+        table_backend: Backend to use for the new ROI tables. Defaults to "csv".
         update_omero_metadata: Whether to update Omero-channels metadata, to
             make them Fractal-compatible.
         overwrite: Whether new ROI tables (added when `add_image_roi_table`

--- a/fractal_tasks_core/import_ome_zarr.py
+++ b/fractal_tasks_core/import_ome_zarr.py
@@ -14,6 +14,7 @@ from ngio import (
     open_ome_zarr_plate,
     open_ome_zarr_well,
 )
+from ngio.ome_zarr_meta.ngio_specs import ChannelsMeta
 from ngio.tables import RoiTable
 from pydantic import validate_call
 
@@ -132,8 +133,10 @@ def _process_single_image(
         channel_names = image.channel_labels
         wavelengths = image.channels_meta.channel_wavelength_ids
         ome_zarr_image.set_channel_meta(
-            labels=channel_names,
-            wavelength_id=wavelengths,
+            channel_meta=ChannelsMeta.default_init(
+                labels=channel_names,
+                wavelength_id=wavelengths,
+            )
         )
 
     type_updates = {

--- a/tests/integration/test_hcs_workflow.py
+++ b/tests/integration/test_hcs_workflow.py
@@ -28,6 +28,7 @@ from ngio import (
     create_empty_plate,
     open_ome_zarr_container,
 )
+from ngio.ome_zarr_meta.ngio_specs import Channel
 from skimage.io import imsave
 
 from fractal_tasks_core._illumination_correction_utils import ProfileCorrectionModel
@@ -63,6 +64,13 @@ from fractal_tasks_core.threshold_segmentation import threshold_segmentation
 # ---------------------------------------------------------------------------
 
 _CHANNELS = ["A01_C01", "A01_C02"]
+# Channel labels are distinct from the wavelength_ids in _CHANNELS, so it's
+# clear the pipeline matches channels by wavelength_id, not by a label that
+# happens to coincide with it.
+_CHANNELS_META = [
+    Channel.default_init(label=f"channel_{i}", wavelength_id=wavelength_id)
+    for i, wavelength_id in enumerate(_CHANNELS)
+]
 _SHAPE = (2, 4, 64, 64)  # czyx: 2 channels, 4 z-slices, 64x64 px
 _PIXELSIZE = 0.325  # µm/px at level 0
 _Z_SPACING = 1.0  # µm/z-slice
@@ -124,7 +132,7 @@ def _build_plate(tmp_path: Path) -> tuple[str, str, str]:
             z_spacing=_Z_SPACING,
             axes_names="czyx",
             levels=_LEVELS,
-            channel_wavelengths=_CHANNELS,
+            channels_meta=_CHANNELS_META,
             overwrite=True,
         )
         data = np.zeros(_SHAPE, dtype=np.uint16)

--- a/tests/integration/test_hcs_workflow.py
+++ b/tests/integration/test_hcs_workflow.py
@@ -32,6 +32,7 @@ from ngio.ome_zarr_meta.ngio_specs import Channel
 from skimage.io import imsave
 
 from fractal_tasks_core._illumination_correction_utils import ProfileCorrectionModel
+from fractal_tasks_core._import_ome_zarr_utils import AdvancedOptions, GridRoiTable
 from fractal_tasks_core._registration_utils import (
     InitArgsRegistration,
     InitArgsRegistrationConsensus,
@@ -199,9 +200,11 @@ def test_full_pipeline(tmp_path: Path) -> None:
     import_result = import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="pipeline_plate.zarr",
-        grid_y_shape=1,
-        grid_x_shape=1,
-        update_omero_metadata=False,
+        advanced_options=AdvancedOptions(
+            add_image_roi_table=True,
+            grid_roi_table=GridRoiTable(grid_y_shape=1, grid_x_shape=1),
+            update_omero_metadata=False,
+        ),
     )
     updates = import_result["image_list_updates"]
     assert len(updates) == 2, f"Expected 2 image updates, got {len(updates)}"

--- a/tests/tasks/test_compute_projection_hcs.py
+++ b/tests/tasks/test_compute_projection_hcs.py
@@ -27,7 +27,7 @@ def sample_ome_zarr_zyx_url(tmp_path: Path) -> Path:
         axes_names="zyx",
     )
     table = origin_ome_zarr.build_image_roi_table("image")
-    origin_ome_zarr.add_table("well_ROI_table", table, backend="anndata")
+    origin_ome_zarr.add_table("well_ROI_table", table, backend="csv")
     return store
 
 
@@ -91,7 +91,7 @@ def test_compute_projection_hcs(
         axes_names=axes,
     )
     table = origin_ome_zarr.build_image_roi_table("image")
-    origin_ome_zarr.add_table("well_ROI_table", table, backend="anndata")
+    origin_ome_zarr.add_table("well_ROI_table", table, backend="csv")
 
     init_mip = InitArgsMIP(
         origin_url=str(store),

--- a/tests/tasks/test_illumination_correction_task.py
+++ b/tests/tasks/test_illumination_correction_task.py
@@ -460,7 +460,7 @@ def test_multidimensional_input(
     )
 
     table = origin_ome_zarr.build_image_roi_table("image")
-    origin_ome_zarr.add_table("well_ROI_table", table, backend="anndata")
+    origin_ome_zarr.add_table("well_ROI_table", table, backend="csv")
 
     # Prepare arguments for illumination_correction function
     testdata_str = testdata_path.as_posix()
@@ -568,7 +568,7 @@ def test_inconsistent_fov_sizes(tmp_path: Path) -> None:
         name="fov_2", slices={"x": (5.0, 10.0), "y": (0.0, 10.0), "z": (0.0, 1.0)}
     )
     roi_table = RoiTable(rois=[roi1, roi2])
-    ome_zarr.add_table("well_ROI_table", roi_table, backend="anndata")
+    ome_zarr.add_table("well_ROI_table", roi_table, backend="csv")
 
     wavelengths = [w for w in ome_zarr.wavelength_ids if w is not None]
     illumination_profiles = ProfileCorrectionModel(
@@ -603,7 +603,7 @@ def _make_tiny_zyx_zarr_with_roi(tmp_path: Path) -> tuple[str, list[str]]:
         levels=2,
     )
     table = ome_zarr.build_image_roi_table("image")
-    ome_zarr.add_table("well_ROI_table", table, backend="anndata")
+    ome_zarr.add_table("well_ROI_table", table, backend="csv")
     wavelengths = [w for w in ome_zarr.wavelength_ids if w is not None]
     return str(store), wavelengths
 

--- a/tests/tasks/test_import_ome_zarr_task.py
+++ b/tests/tasks/test_import_ome_zarr_task.py
@@ -10,6 +10,7 @@ from ngio import (
 from ngio.tables import RoiTable
 from ngio.utils import NgioValueError
 
+from fractal_tasks_core._import_ome_zarr_utils import AdvancedOptions, GridRoiTable
 from fractal_tasks_core.import_ome_zarr import (
     import_ome_zarr,
     open_unknown_container,
@@ -102,9 +103,11 @@ def test_import_plate(
     result = import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="plate.zarr",
-        grid_y_shape=2,
-        grid_x_shape=2,
-        update_omero_metadata=False,
+        advanced_options=AdvancedOptions(
+            add_image_roi_table=True,
+            grid_roi_table=GridRoiTable(grid_y_shape=2, grid_x_shape=2),
+            update_omero_metadata=False,
+        ),
     )
 
     updates = result["image_list_updates"]
@@ -124,7 +127,11 @@ def test_import_well(tmp_path: Path) -> None:
     result = import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="plate.zarr/A/01",
-        update_omero_metadata=False,
+        advanced_options=AdvancedOptions(
+            add_image_roi_table=True,
+            grid_roi_table=GridRoiTable(),
+            update_omero_metadata=False,
+        ),
     )
 
     updates = result["image_list_updates"]
@@ -140,7 +147,11 @@ def test_import_image(tmp_path: Path) -> None:
     result = import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="plate.zarr/A/01/0",
-        update_omero_metadata=False,
+        advanced_options=AdvancedOptions(
+            add_image_roi_table=True,
+            grid_roi_table=GridRoiTable(),
+            update_omero_metadata=False,
+        ),
     )
 
     updates = result["image_list_updates"]
@@ -155,9 +166,7 @@ def test_import_roi_tables_disabled(tmp_path: Path) -> None:
     result = import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="plate.zarr",
-        add_image_roi_table=False,
-        add_grid_roi_table=False,
-        update_omero_metadata=False,
+        advanced_options=AdvancedOptions(update_omero_metadata=False),
     )
 
     for update in result["image_list_updates"]:
@@ -171,15 +180,33 @@ def test_import_overwrite(tmp_path: Path) -> None:
     _make_image(tmp_path)
 
     # First import creates both ROI tables
-    import_ome_zarr(zarr_dir=str(tmp_path), zarr_name="image.zarr")
+    import_ome_zarr(
+        zarr_dir=str(tmp_path),
+        zarr_name="image.zarr",
+        advanced_options=AdvancedOptions(
+            add_image_roi_table=True, grid_roi_table=GridRoiTable()
+        ),
+    )
 
     # Re-import with overwrite=False (default) raises because tables already exist
     with pytest.raises(NgioValueError):
-        import_ome_zarr(zarr_dir=str(tmp_path), zarr_name="image.zarr", overwrite=False)
+        import_ome_zarr(
+            zarr_dir=str(tmp_path),
+            zarr_name="image.zarr",
+            advanced_options=AdvancedOptions(
+                add_image_roi_table=True,
+                grid_roi_table=GridRoiTable(),
+                overwrite=False,
+            ),
+        )
 
     # Re-import with overwrite=True succeeds and returns valid updates
     result = import_ome_zarr(
-        zarr_dir=str(tmp_path), zarr_name="image.zarr", overwrite=True
+        zarr_dir=str(tmp_path),
+        zarr_name="image.zarr",
+        advanced_options=AdvancedOptions(
+            add_image_roi_table=True, grid_roi_table=GridRoiTable(), overwrite=True
+        ),
     )
     assert len(result["image_list_updates"]) == 1
 
@@ -191,8 +218,12 @@ def test_import_explicit_table_backend(tmp_path: Path) -> None:
     result = import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="image.zarr",
-        table_backend="parquet",
-        update_omero_metadata=False,
+        advanced_options=AdvancedOptions(
+            add_image_roi_table=True,
+            grid_roi_table=GridRoiTable(),
+            table_backend="parquet",
+            update_omero_metadata=False,
+        ),
     )
 
     updates = result["image_list_updates"]
@@ -226,10 +257,10 @@ def test_grid_roi_table_roi_count(
     import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="image.zarr",
-        grid_y_shape=grid_y,
-        grid_x_shape=grid_x,
-        add_image_roi_table=False,
-        update_omero_metadata=False,
+        advanced_options=AdvancedOptions(
+            grid_roi_table=GridRoiTable(grid_y_shape=grid_y, grid_x_shape=grid_x),
+            update_omero_metadata=False,
+        ),
     )
 
     ome_zarr = open_ome_zarr_container(str(image_path))
@@ -246,10 +277,10 @@ def test_grid_roi_table_roi_extent(tmp_path: Path) -> None:
     import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="image.zarr",
-        grid_y_shape=2,
-        grid_x_shape=2,
-        add_image_roi_table=False,
-        update_omero_metadata=False,
+        advanced_options=AdvancedOptions(
+            grid_roi_table=GridRoiTable(grid_y_shape=2, grid_x_shape=2),
+            update_omero_metadata=False,
+        ),
     )
 
     grid_table = open_ome_zarr_container(str(image_path)).get_table("grid_ROI_table")
@@ -268,9 +299,7 @@ def test_import_omero_metadata_update(tmp_path: Path) -> None:
     import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="image.zarr",
-        update_omero_metadata=True,
-        add_image_roi_table=False,
-        add_grid_roi_table=False,
+        advanced_options=AdvancedOptions(update_omero_metadata=True),
     )
 
     image = open_ome_zarr_container(str(tmp_path / "image.zarr")).get_image()
@@ -285,9 +314,7 @@ def test_import_plate_omero_metadata_update(tmp_path: Path) -> None:
     result = import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="plate.zarr",
-        update_omero_metadata=True,
-        add_image_roi_table=False,
-        add_grid_roi_table=False,
+        advanced_options=AdvancedOptions(update_omero_metadata=True),
     )
 
     for update in result["image_list_updates"]:
@@ -303,9 +330,7 @@ def test_import_well_omero_metadata_update(tmp_path: Path) -> None:
     result = import_ome_zarr(
         zarr_dir=str(tmp_path),
         zarr_name="plate.zarr/A/01",
-        update_omero_metadata=True,
-        add_image_roi_table=False,
-        add_grid_roi_table=False,
+        advanced_options=AdvancedOptions(update_omero_metadata=True),
     )
 
     for update in result["image_list_updates"]:

--- a/tests/tasks/test_import_ome_zarr_task.py
+++ b/tests/tasks/test_import_ome_zarr_task.py
@@ -68,11 +68,15 @@ def _make_image(
     return image_path
 
 
-def _check_roi_tables(image_url: str) -> None:
-    """Assert both image_ROI_table and grid_ROI_table are present."""
-    tables = open_ome_zarr_container(image_url).list_tables()
+def _check_roi_tables(image_url: str, expected_backend: str = "csv") -> None:
+    """Assert both image_ROI_table and grid_ROI_table are present with the
+    expected backend."""
+    ome_zarr = open_ome_zarr_container(image_url)
+    tables = ome_zarr.list_tables()
     assert "image_ROI_table" in tables
     assert "grid_ROI_table" in tables
+    assert ome_zarr.get_table("image_ROI_table").backend_name == expected_backend
+    assert ome_zarr.get_table("grid_ROI_table").backend_name == expected_backend
 
 
 # ---------------------------------------------------------------------------
@@ -178,6 +182,22 @@ def test_import_overwrite(tmp_path: Path) -> None:
         zarr_dir=str(tmp_path), zarr_name="image.zarr", overwrite=True
     )
     assert len(result["image_list_updates"]) == 1
+
+
+def test_import_explicit_table_backend(tmp_path: Path) -> None:
+    """table_backend='parquet' overrides the default and applies to both ROI tables."""
+    _make_image(tmp_path)
+
+    result = import_ome_zarr(
+        zarr_dir=str(tmp_path),
+        zarr_name="image.zarr",
+        table_backend="parquet",
+        update_omero_metadata=False,
+    )
+
+    updates = result["image_list_updates"]
+    assert len(updates) == 1
+    _check_roi_tables(updates[0]["zarr_url"], expected_backend="parquet")
 
 
 @pytest.mark.parametrize(

--- a/tests/tasks/test_init_projection_hcs.py
+++ b/tests/tasks/test_init_projection_hcs.py
@@ -59,7 +59,7 @@ def _add_images_to_plate(
             axes_names=axes,
         )
         table = ome_zarr.build_image_roi_table("image")
-        ome_zarr.add_table("well_ROI_table", table, backend="anndata")
+        ome_zarr.add_table("well_ROI_table", table, backend="csv")
     return plate
 
 

--- a/tests/tasks/test_measure_features_task.py
+++ b/tests/tasks/test_measure_features_task.py
@@ -327,18 +327,33 @@ def test_measure_features_advanced_options_no_scaling(tmp_path: Path) -> None:
 
 
 def test_measure_features_advanced_options_table_backend(tmp_path: Path) -> None:
-    """table_backend='parquet' stores the table correctly."""
+    """table_backend='csv' stores the table with the csv backend."""
     store = _make_zarr_with_label(tmp_path)
 
     measure_features(
         zarr_url=str(store),
         input_label_name="nuclei",
         features=[ShapeFeatures()],
-        advanced_options=AdvancedOptions(table_backend="parquet"),
+        advanced_options=AdvancedOptions(table_backend="csv"),
     )
 
     some = open_ome_zarr_container(str(store))
     assert "region_props_features" in some.list_tables()
+    assert some.get_table("region_props_features").backend_name == "csv"
+
+
+def test_measure_features_default_table_backend(tmp_path: Path) -> None:
+    """The default table backend for the output feature table is parquet."""
+    store = _make_zarr_with_label(tmp_path)
+
+    measure_features(
+        zarr_url=str(store),
+        input_label_name="nuclei",
+        features=[ShapeFeatures()],
+    )
+
+    some = open_ome_zarr_container(str(store))
+    assert some.get_table("region_props_features").backend_name == "parquet"
 
 
 def test_intensity_features_with_channels(tmp_path: Path) -> None:

--- a/tests/tasks/test_projection_task.py
+++ b/tests/tasks/test_projection_task.py
@@ -13,7 +13,13 @@ from fractal_tasks_core.projection import projection
 # ---------------------------------------------------------------------------
 
 
-def _make_zarr(tmp_path: Path, shape: tuple, axes: str, name: str = "image") -> Path:
+def _make_zarr(
+    tmp_path: Path,
+    shape: tuple,
+    axes: str,
+    name: str = "image",
+    backend: str = "anndata",
+) -> Path:
     store = tmp_path / f"{name}.zarr"
     some = create_empty_ome_zarr(
         store=store,
@@ -24,7 +30,7 @@ def _make_zarr(tmp_path: Path, shape: tuple, axes: str, name: str = "image") -> 
         axes_names=axes,
     )
     table = some.build_image_roi_table("image")
-    some.add_table("well_ROI_table", table, backend="anndata")
+    some.add_table("well_ROI_table", table, backend=backend)
     return store
 
 
@@ -154,3 +160,17 @@ def test_projection_roi_table_z_update(tmp_path: Path) -> None:
     assert z_slice is not None
     assert z_slice.start == 0
     assert z_slice.length == 1
+
+
+@pytest.mark.parametrize("backend", ["anndata", "csv", "parquet", "json"])
+def test_projection_preserves_input_table_backend(backend: str, tmp_path: Path) -> None:
+    """Output ROI table backend matches the input table's backend, not a
+    hardcoded one."""
+    store = _make_zarr(tmp_path, shape=(16, 32, 32), axes="zyx", backend=backend)
+
+    result = projection(zarr_url=str(store))
+
+    zarr_url = result["image_list_updates"][0]["zarr_url"]
+    out = open_ome_zarr_container(zarr_url)
+    table = out.get_table("well_ROI_table")
+    assert table.backend_name == backend

--- a/tests/tasks/test_projection_task.py
+++ b/tests/tasks/test_projection_task.py
@@ -18,7 +18,7 @@ def _make_zarr(
     shape: tuple,
     axes: str,
     name: str = "image",
-    backend: str = "anndata",
+    backend: str = "csv",
 ) -> Path:
     store = tmp_path / f"{name}.zarr"
     some = create_empty_ome_zarr(

--- a/tests/tasks/test_registration_pipeline_task.py
+++ b/tests/tasks/test_registration_pipeline_task.py
@@ -21,6 +21,7 @@ from ngio import (
     open_ome_zarr_container,
     open_ome_zarr_well,
 )
+from ngio.ome_zarr_meta.ngio_specs import Channel
 from ngio.tables import FeatureTable, RoiTable
 from pandas import DataFrame
 
@@ -54,6 +55,10 @@ _SHAPE = (1, 1, 64, 64)  # czyx
 _PIXELSIZE = 0.325  # um/px at level 0
 _LEVELS = 3  # level 2 = 16x16 px, pixel size = 0.325*4 = 1.3 um/px
 _WAVELENGTH = "A01_C01"
+# Channel label is distinct from the wavelength_id, so it's clear the tests
+# match channels by wavelength_id (as the registration task does) and not by
+# a label that happens to coincide with it.
+_CHANNEL_META = Channel.default_init(label="channel_0", wavelength_id=_WAVELENGTH)
 
 # Known shift applied to acquisition 1 (pixels at level 0)
 _SHIFT_Y_PX = 4
@@ -78,7 +83,7 @@ def _build_image(zarr_url: str, y_offset: int = 0, x_offset: int = 0) -> None:
         z_spacing=1.0,
         axes_names="czyx",
         levels=_LEVELS,
-        channel_wavelengths=[_WAVELENGTH],
+        channels_meta=[_CHANNEL_META],
         overwrite=True,
     )
     img = some.get_image()
@@ -113,7 +118,7 @@ def _build_image_for_axes(
         "pixelsize": _PIXELSIZE,
         "axes_names": axes,
         "levels": _LEVELS,
-        "channel_wavelengths": [_WAVELENGTH],
+        "channels_meta": [_CHANNEL_META],
         "overwrite": True,
     }
     if "z" in axes:
@@ -148,7 +153,7 @@ def _build_multi_fov_image(zarr_url: str, y_offset: int = 0, x_offset: int = 0) 
         z_spacing=1.0,
         axes_names="czyx",
         levels=_LEVELS,
-        channel_wavelengths=[_WAVELENGTH],
+        channels_meta=[_CHANNEL_META],
         overwrite=True,
     )
     data = np.zeros(_SHAPE, dtype=np.uint16)
@@ -414,7 +419,7 @@ def test_calculate_registration_detects_z_shift(tmp_path: Path):
             z_spacing=1.0,
             axes_names="czyx",
             levels=_LEVELS,
-            channel_wavelengths=[_WAVELENGTH],
+            channels_meta=[_CHANNEL_META],
             overwrite=True,
         )
         data = np.zeros(shape, dtype=np.uint16)
@@ -451,7 +456,7 @@ def test_calculate_registration_chi2_shift_3d_raises(tmp_path: Path):
         z_spacing=1.0,
         axes_names="czyx",
         levels=3,
-        channel_wavelengths=[_WAVELENGTH],
+        channels_meta=[_CHANNEL_META],
         overwrite=True,
     )
     fov = some.build_image_roi_table("image")
@@ -478,7 +483,7 @@ def test_calculate_registration_time_series_raises(tmp_path: Path):
         z_spacing=1.0,
         axes_names="tczyx",
         levels=3,
-        channel_wavelengths=[_WAVELENGTH],
+        channels_meta=[_CHANNEL_META],
         overwrite=True,
     )
     fov = some.build_image_roi_table("image")
@@ -670,7 +675,7 @@ def test_calculate_registration_shape_mismatch_raises(tmp_path: Path):
             z_spacing=1.0,
             axes_names="czyx",
             levels=_LEVELS,
-            channel_wavelengths=[_WAVELENGTH],
+            channels_meta=[_CHANNEL_META],
             overwrite=True,
         )
         data = np.zeros(shape, dtype=np.uint16)
@@ -773,7 +778,7 @@ def test_consensus_mismatched_roi_names_raises(tmp_path: Path):
             z_spacing=1.0,
             axes_names="czyx",
             levels=_LEVELS,
-            channel_wavelengths=[_WAVELENGTH],
+            channels_meta=[_CHANNEL_META],
             overwrite=True,
         )
         fov = some.build_image_roi_table(roi_name)
@@ -1320,7 +1325,7 @@ def test_calculate_registration_tyx_t_gt1_raises(tmp_path: Path):
         pixelsize=_PIXELSIZE,
         axes_names="tyx",
         levels=_LEVELS,
-        channel_wavelengths=[_WAVELENGTH],
+        channels_meta=[_CHANNEL_META],
         overwrite=True,
     )
     fov = some.build_image_roi_table("image")

--- a/tests/tasks/test_registration_pipeline_task.py
+++ b/tests/tasks/test_registration_pipeline_task.py
@@ -71,7 +71,7 @@ _SHIFT_X_UM = 2.6  # um
 _SHIFT_Z_PX = 2
 _SHIFT_Z_UM = 2.0  # um
 # Table backend
-_TABLE_BACKEND = "anndata"
+_TABLE_BACKEND = "csv"
 
 
 def _build_image(zarr_url: str, y_offset: int = 0, x_offset: int = 0) -> None:

--- a/tests/tasks/test_threshold_segmentation_task.py
+++ b/tests/tasks/test_threshold_segmentation_task.py
@@ -256,6 +256,24 @@ def test_create_masking_roi_table(tmp_path: Path) -> None:
 
     some = open_ome_zarr_container(str(store))
     assert "nuclei_masking_ROI_table" in some.list_tables()
+    assert some.get_table("nuclei_masking_ROI_table").backend_name == "csv"
+
+
+def test_create_masking_roi_table_explicit_backend(tmp_path: Path) -> None:
+    """table_backend='parquet' overrides the default csv backend."""
+    store = _make_czyx_zarr(tmp_path)
+
+    threshold_segmentation(
+        zarr_url=str(store),
+        channel=InputChannel(mode="index", identifier="0"),
+        output_label_name="nuclei",
+        segmentation_method=SimpleThresholdConfiguration(threshold=500),
+        create_masking_roi_table=CreateMaskingRoiTable(table_backend="parquet"),
+        overwrite=True,
+    )
+
+    some = open_ome_zarr_container(str(store))
+    assert some.get_table("nuclei_masking_ROI_table").backend_name == "parquet"
 
 
 def test_with_gaussian_preprocess(tmp_path: Path) -> None:


### PR DESCRIPTION
Fix table copying in `apply_registration_to_image` task: Use the existing table backend for the newly written table, perform table writing outside the try/except loop to catch reading race conditions and provide reading exception in the Runtime Error.

Closes #1061 and #1062 

Additionally, switch the default table backends: parquet for feature measurement table, csv for ROI tables (import task & masking ROI tables in threshold segmentation).

Closes #1064 

Finally, refactored UI for Import OME-Zarr task to hide advanced options and change default behaviors to not add ROI tables / change Omero metadata.

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
